### PR TITLE
Rename package from mcp-wordpress-remote-proxy to mcp-wordpress-remot…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
-	"name": "mcp-wordpress-remote-proxy",
-	"version": "1.0.6",
+	"name": "mcp-wordpress-remote",
+	"version": "0.1.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "mcp-wordpress-remote-proxy",
-			"version": "1.0.6",
+			"name": "mcp-wordpress-remote",
+			"version": "0.1.6",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.8.0",
 				"express": "^4.18.2",
 				"open": "^10.0.0"
 			},
 			"bin": {
-				"mcp-wordpress-remote-proxy": "dist/proxy.js"
+				"mcp-wordpress-remote": "dist/proxy.js"
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "mcp-wordpress-remote-proxy",
-	"version": "1.0.6",
+	"name": "mcp-wordpress-remote",
+	"version": "0.1.6",
 	"description": "MCP WordPress Remote proxy server",
 	"keywords": [
 		"mcp",
@@ -11,7 +11,7 @@
 	"author": "Ovidiu Iulian Galatan",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/galatanovidiu/wp-wordpress-remote-proxy.git"
+		"url": "git+https://github.com/Automattic/mcp-wordpress-remote.git"
 	},
 	"type": "module",
 	"files": [
@@ -21,7 +21,7 @@
 	],
 	"main": "dist/proxy.js",
 	"bin": {
-		"mcp-wordpress-remote-proxy": "dist/proxy.js"
+		"mcp-wordpress-remote": "dist/proxy.js"
 	},
 	"scripts": {
 		"build": "tsup",


### PR DESCRIPTION
…e and update version to 0.1.6