### PR TITLE
Add Library Exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.2.11",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/mcp-wordpress-remote",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
         "express": "^4.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.2.11",
+  "version": "0.2.13",
   "description": "MCP WordPress Remote proxy server",
   "engines": {
     "node": ">=18.0.0"
@@ -23,6 +23,16 @@
     "LICENSE"
   ],
   "main": "dist/proxy.js",
+  "exports": {
+    ".": {
+      "import": "./dist/proxy.js",
+      "types": "./dist/proxy.d.ts"
+    },
+    "./lib": {
+      "import": "./dist/lib.js",
+      "types": "./dist/lib.d.ts"
+    }
+  },
   "bin": {
     "@automattic/mcp-wordpress-remote": "dist/proxy.js"
   },
@@ -71,7 +81,8 @@
   },
   "tsup": {
     "entry": [
-      "src/proxy.ts"
+      "src/proxy.ts",
+      "src/lib.ts"
     ],
     "format": [
       "esm"
@@ -79,6 +90,7 @@
     "dts": true,
     "clean": true,
     "outDir": "dist",
+    "splitting": false,
     "noExternal": [
       "@modelcontextprotocol/sdk",
       "express",

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,31 @@
+/**
+ * MCP WordPress Remote - Library Exports
+ *
+ * This file exports logger, configuration, types, and utilities for external packages.
+ * Import via: @automattic/mcp-wordpress-remote/lib
+ */
+
+// Export logger and logging utilities
+export { logger, log, LogLevel } from './lib/utils.js';
+
+// Export configuration utilities
+export { CONFIG, getConfig, validateConfig, getDefaultOAuthScopes } from './lib/config.js';
+
+// Export common types
+export type { WPTokens, WPClientInfo, TokenValidationResult } from './lib/oauth-types.js';
+export type { WordPressRequestParams, WordPressResponse } from './lib/types.js';
+
+// Export error types
+export {
+  OAuthError,
+  AuthError,
+  APIError,
+  ConfigError,
+  isOAuthError,
+  isAuthError,
+  isAPIError,
+  isConfigError,
+} from './lib/oauth-types.js';
+
+// Export version
+export { MCP_WORDPRESS_REMOTE_VERSION } from './lib/utils.js';

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { InitializeResult } from './lib/types.js';


### PR DESCRIPTION
## Summary
Enable external packages to import utilities, types, and configuration from `@automattic/mcp-wordpress-remote`.

## Changes
- **Version bump**: 0.2.11 → 0.2.13
- **New library exports**: Added `src/lib.ts` with comprehensive exports
- **Package exports**: Added `exports` field to `package.json` for both main proxy and library imports
- **Build config**: Added `src/lib.ts` to build entries
- **Cleanup**: Removed shebang from `src/proxy.ts`

## What's Exported
- Logger and utilities (`logger`, `log`, `LogLevel`)
- Configuration (`CONFIG`, `getConfig`, `validateConfig`)
- Types (`WPTokens`, `WordPressRequestParams`, etc.)
- Error classes (`OAuthError`, `AuthError`, `APIError`, `ConfigError`)
- Version info (`MCP_WORDPRESS_REMOTE_VERSION`)

## Usage
```typescript
// Main proxy
import proxy from '@automattic/mcp-wordpress-remote';

// Library utilities
import { logger, CONFIG, OAuthError } from '@automattic/mcp-wordpress-remote/lib';
```

## Benefits
- Enables code reuse across WordPress MCP packages
- Provides type-safe imports
- Maintains backward compatibility