### PR TITLE
add: proxy support via USE_SYSTEM_PROXY config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,14 @@
       "version": "0.2.18",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
         "express": "^4.18.2",
+        "https-proxy-agent": "^7.0.6",
         "node-fetch": "^3.3.2",
-        "open": "^10.0.0"
+        "open": "^10.0.0",
+        "pac-resolver": "^7.0.1",
+        "quickjs-emscripten": "^0.31.0",
+        "socks-proxy-agent": "^8.0.5"
       },
       "bin": {
         "mcp-wordpress-remote": "dist/proxy.js"
@@ -1386,6 +1391,48 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jitl/quickjs-ffi-types": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-ffi-types/-/quickjs-ffi-types-0.31.0.tgz",
+      "integrity": "sha512-1yrgvXlmXH2oNj3eFTrkwacGJbmM0crwipA3ohCrjv52gBeDaD7PsTvFYinlAnqU8iPME3LGP437yk05a2oejw==",
+      "license": "MIT"
+    },
+    "node_modules/@jitl/quickjs-wasmfile-debug-asyncify": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-debug-asyncify/-/quickjs-wasmfile-debug-asyncify-0.31.0.tgz",
+      "integrity": "sha512-YkdzQdr1uaftFhgEnTRjTTZHk2SFZdpWO7XhOmRVbi6CEVsH9g5oNF8Ta1q3OuSJHRwwT8YsuR1YzEiEIJEk6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.31.0"
+      }
+    },
+    "node_modules/@jitl/quickjs-wasmfile-debug-sync": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-debug-sync/-/quickjs-wasmfile-debug-sync-0.31.0.tgz",
+      "integrity": "sha512-8XvloaaWBONqcHXYs5tWOjdhQVxzULilIfB2hvZfS6S+fI4m2+lFiwQy7xeP8ExHmiZ7D8gZGChNkdLgjGfknw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.31.0"
+      }
+    },
+    "node_modules/@jitl/quickjs-wasmfile-release-asyncify": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-release-asyncify/-/quickjs-wasmfile-release-asyncify-0.31.0.tgz",
+      "integrity": "sha512-uz0BbQYTxNsFkvkurd7vk2dOg57ElTBLCuvNtRl4rgrtbC++NIndD5qv2+AXb6yXDD3Uy1O2PCwmoaH0eXgEOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.31.0"
+      }
+    },
+    "node_modules/@jitl/quickjs-wasmfile-release-sync": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-release-sync/-/quickjs-wasmfile-release-sync-0.31.0.tgz",
+      "integrity": "sha512-hYduecOByj9AsAfsJhZh5nA6exokmuFC8cls39+lYmTCGY51bgjJJJwReEu7Ff7vBWaQCL6TeDdVlnp2WYz0jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.31.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
@@ -2099,6 +2146,12 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2396,6 +2449,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2481,6 +2543,18 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -3251,6 +3325,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3513,11 +3601,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -3525,6 +3633,24 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -4153,6 +4279,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -4222,6 +4361,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -5448,6 +5596,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/nock": {
       "version": "14.0.9",
       "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.9.tgz",
@@ -5674,6 +5831,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -6040,6 +6210,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quickjs-emscripten": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/quickjs-emscripten/-/quickjs-emscripten-0.31.0.tgz",
+      "integrity": "sha512-K7Yt78aRPLjPcqv3fIuLW1jW3pvwO21B9pmFOolsjM/57ZhdVXBr51GqJpalgBlkPu9foAvhEAuuQPnvIGvLvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-wasmfile-debug-asyncify": "0.31.0",
+        "@jitl/quickjs-wasmfile-debug-sync": "0.31.0",
+        "@jitl/quickjs-wasmfile-release-asyncify": "0.31.0",
+        "@jitl/quickjs-wasmfile-release-sync": "0.31.0",
+        "quickjs-emscripten-core": "0.31.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/quickjs-emscripten-core": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/quickjs-emscripten-core/-/quickjs-emscripten-core-0.31.0.tgz",
+      "integrity": "sha512-oQz8p0SiKDBc1TC7ZBK2fr0GoSHZKA0jZIeXxsnCyCs4y32FStzCW4d1h6E1sE0uHDMbGITbk2zhNaytaoJwXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.31.0"
       }
     },
     "node_modules/range-parser": {
@@ -6450,11 +6645,49 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6987,6 +7220,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsup": {
       "version": "8.4.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "node-fetch": "^3.3.2",
     "open": "^10.0.0",
     "pac-resolver": "^7.0.1",
-    "quickjs-emscripten": "^0.31.0",
     "socks-proxy-agent": "^8.0.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -59,9 +59,14 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.8.0",
+    "@tootallnate/quickjs-emscripten": "^0.23.0",
     "express": "^4.18.2",
+    "https-proxy-agent": "^7.0.6",
     "node-fetch": "^3.3.2",
-    "open": "^10.0.0"
+    "open": "^10.0.0",
+    "pac-resolver": "^7.0.1",
+    "quickjs-emscripten": "^0.31.0",
+    "socks-proxy-agent": "^8.0.5"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",
@@ -101,7 +106,11 @@
       "open"
     ],
     "external": [
-      "node:*"
+      "node:*",
+      "@tootallnate/quickjs-emscripten",
+      "pac-resolver",
+      "socks-proxy-agent",
+      "https-proxy-agent"
     ],
     "minify": false,
     "sourcemap": false,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -32,3 +32,9 @@ export {
 
 // Export version
 export { MCP_WORDPRESS_REMOTE_VERSION } from './lib/utils.js';
+
+// Export fetch utilities (including proxy support)
+export { setupFetchPolyfill, proxyFetch, getProxyInfo, isFetchAvailable, getFetchInfo } from './lib/fetch-utils.js';
+
+// Export proxy utilities
+export { initializeProxy, isProxyConfigured, getProxyType, getAgentForUrl } from './lib/proxy-utils.js';

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -64,6 +64,9 @@ export const CONFIG = {
 
   // Environment
   NODE_ENV: process.env.NODE_ENV || 'development',
+
+  // Proxy Configuration
+  USE_SYSTEM_PROXY: process.env.USE_SYSTEM_PROXY === 'true', // Enable system proxy detection (PAC files, env vars)
 } as const;
 
 /**
@@ -132,6 +135,9 @@ export const getConfig = () => ({
 
   /** Current environment */
   nodeEnv: CONFIG.NODE_ENV,
+
+  /** Whether to use system proxy (PAC files on macOS, env vars on all platforms) */
+  useSystemProxy: CONFIG.USE_SYSTEM_PROXY,
 });
 
 /**
@@ -177,7 +183,7 @@ export function parseCustomHeaders(customHeadersString: string): Record<string, 
     // Parse comma-separated format
     const headers: Record<string, string> = {};
     const pairs = customHeadersString.split(',');
-    
+
     for (const pair of pairs) {
       const colonIndex = pair.indexOf(':');
       if (colonIndex > 0) {

--- a/src/lib/fetch-utils.ts
+++ b/src/lib/fetch-utils.ts
@@ -2,12 +2,21 @@
  * Fetch API utilities for MCP WordPress Remote
  *
  * Provides fetch polyfill setup for Node.js environments that don't have native fetch
- * and proxy-aware fetch for routing through system proxies (PAC files, SSH tunnels, etc.)
+ * and proxy-aware fetch for routing through system proxies (PAC files, env-based SOCKS/HTTP proxies)
  */
 
+import type { RequestInit as NodeFetchRequestInit } from 'node-fetch';
+import type { Agent } from 'http';
 import { logger } from './utils.js';
 import { getConfig } from './config.js';
 import { initializeProxy, getAgentForUrl, isProxyConfigured, getProxyType } from './proxy-utils.js';
+
+/**
+ * Extended RequestInit that includes the agent property for proxy support
+ */
+interface ProxyRequestInit extends NodeFetchRequestInit {
+  agent?: Agent;
+}
 
 /**
  * Setup fetch polyfill for Node.js 18+ compatibility
@@ -65,7 +74,7 @@ export async function proxyFetch(url: string, init?: RequestInit): Promise<Respo
   if (agent) {
     // Use node-fetch with agent for SOCKS/HTTP proxy support
     const nodeFetch = (await import('node-fetch')).default;
-    return nodeFetch(url, { ...init, agent } as any) as unknown as Response;
+    return nodeFetch(url, { ...init, agent } as ProxyRequestInit) as unknown as Response;
   }
 
   // Direct connection (no proxy configured or PAC returned DIRECT)

--- a/src/lib/fetch-utils.ts
+++ b/src/lib/fetch-utils.ts
@@ -1,16 +1,20 @@
 /**
  * Fetch API utilities for MCP WordPress Remote
- * 
+ *
  * Provides fetch polyfill setup for Node.js environments that don't have native fetch
+ * and proxy-aware fetch for routing through system proxies (PAC files, SSH tunnels, etc.)
  */
 
 import { logger } from './utils.js';
+import { getConfig } from './config.js';
+import { initializeProxy, getAgentForUrl, isProxyConfigured, getProxyType } from './proxy-utils.js';
 
 /**
  * Setup fetch polyfill for Node.js 18+ compatibility
- * 
+ *
  * Checks if native fetch is available and loads node-fetch polyfill if needed.
  * This ensures compatibility across different Node.js versions.
+ * Also initializes proxy support for system proxies (PAC files, env vars).
  */
 export async function setupFetchPolyfill(): Promise<void> {
   if (typeof globalThis.fetch !== 'function') {
@@ -30,11 +34,57 @@ export async function setupFetchPolyfill(): Promise<void> {
   } else {
     logger.info('Using native fetch API', 'SYSTEM');
   }
+
+  // Initialize proxy support if enabled (PAC file on macOS, env vars on all platforms)
+  if (getConfig().useSystemProxy) {
+    await initializeProxy();
+  } else {
+    logger.debug('System proxy support disabled (USE_SYSTEM_PROXY=false)', 'PROXY');
+  }
+}
+
+/**
+ * Proxy-aware fetch that routes requests through system proxies when configured
+ *
+ * On macOS: Evaluates PAC file from system proxy settings to determine proxy per-URL
+ * On Linux/other: Uses SOCKS_PROXY, HTTPS_PROXY, etc. environment variables
+ * Falls back to direct connection if no proxy is configured or USE_SYSTEM_PROXY=false
+ *
+ * @param url - The URL to fetch
+ * @param init - Optional fetch init options
+ * @returns Promise resolving to the Response
+ */
+export async function proxyFetch(url: string, init?: RequestInit): Promise<Response> {
+  // Skip proxy lookup if system proxy is disabled
+  if (!getConfig().useSystemProxy) {
+    return fetch(url, init);
+  }
+
+  const agent = await getAgentForUrl(url);
+
+  if (agent) {
+    // Use node-fetch with agent for SOCKS/HTTP proxy support
+    const nodeFetch = (await import('node-fetch')).default;
+    return nodeFetch(url, { ...init, agent } as any) as unknown as Response;
+  }
+
+  // Direct connection (no proxy configured or PAC returned DIRECT)
+  return fetch(url, init);
+}
+
+/**
+ * Get proxy status information for logging/debugging
+ */
+export function getProxyInfo() {
+  return {
+    configured: isProxyConfigured(),
+    type: getProxyType(),
+  };
 }
 
 /**
  * Check if fetch is available (either native or polyfilled)
- * 
+ *
  * @returns true if fetch is available, false otherwise
  */
 export function isFetchAvailable(): boolean {
@@ -43,13 +93,13 @@ export function isFetchAvailable(): boolean {
 
 /**
  * Get information about the current fetch implementation
- * 
+ *
  * @returns Object with details about fetch availability and type
  */
 export function getFetchInfo() {
   const isAvailable = isFetchAvailable();
   const isNative = isAvailable && globalThis.fetch.toString().includes('[native code]');
-  
+
   return {
     available: isAvailable,
     native: isNative,

--- a/src/lib/mcp-oauth-provider.ts
+++ b/src/lib/mcp-oauth-provider.ts
@@ -42,6 +42,7 @@ import {
 import { setupWPOAuthCallbackServer } from './oauth-callback-server.js';
 import { logger } from './utils.js';
 import { CONFIG, getDefaultOAuthScopes, getOAuthCallbackPort, getCustomHeaders } from './config.js';
+import { proxyFetch } from './fetch-utils.js';
 
 /**
  * MCP-compliant OAuth 2.1 Provider for WordPress
@@ -64,7 +65,7 @@ export class MCPOAuthProvider {
   constructor(options: Partial<MCPOAuthConfig>) {
     const serverUrl = options.serverUrl || CONFIG.WP_API_URL;
     const defaultScopes = getDefaultOAuthScopes();
-    
+
     // Build MCP-compliant configuration
     this.config = {
       serverUrl,
@@ -172,7 +173,7 @@ export class MCPOAuthProvider {
 
       // Make an unauthenticated request to trigger 401 with WWW-Authenticate header
       const customHeaders = getCustomHeaders();
-      const response = await fetch(this.config.serverUrl, {
+      const response = await proxyFetch(this.config.serverUrl, {
         headers: {
           Accept: 'application/json',
           ...customHeaders,
@@ -187,7 +188,7 @@ export class MCPOAuthProvider {
 
           if (authInfo.resource_metadata_url) {
             // Fetch protected resource metadata from the indicated URL
-            const metadataResponse = await fetch(authInfo.resource_metadata_url, {
+            const metadataResponse = await proxyFetch(authInfo.resource_metadata_url, {
               headers: {
                 'Accept': 'application/json',
                 ...customHeaders,

--- a/src/lib/mcp-oauth-utils.ts
+++ b/src/lib/mcp-oauth-utils.ts
@@ -15,6 +15,7 @@ import {
 } from './oauth-types.js';
 import { logger } from './utils.js';
 import { getCustomHeaders } from './config.js';
+import { proxyFetch } from './fetch-utils.js';
 
 /**
  * Generate PKCE code verifier and challenge
@@ -75,7 +76,7 @@ export async function discoverAuthorizationServerMetadata(
 
     // Include custom headers in discovery requests
     const customHeaders = getCustomHeaders();
-    const response = await fetch(metadataUrl.toString(), {
+    const response = await proxyFetch(metadataUrl.toString(), {
       headers: {
         'Accept': 'application/json',
         ...customHeaders,
@@ -126,7 +127,7 @@ export async function discoverProtectedResourceMetadata(
 
     // Include custom headers in discovery requests
     const customHeaders = getCustomHeaders();
-    const response = await fetch(metadataUrl.toString(), {
+    const response = await proxyFetch(metadataUrl.toString(), {
       headers: {
         'Accept': 'application/json',
         ...customHeaders,
@@ -215,7 +216,7 @@ export async function registerDynamicClient(
 
     // Include custom headers in registration requests
     const customHeaders = getCustomHeaders();
-    const response = await fetch(registrationEndpoint, {
+    const response = await proxyFetch(registrationEndpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -289,7 +290,7 @@ export async function exchangeAuthorizationCode(
 
     // Include custom headers in token exchange requests
     const customHeaders = getCustomHeaders();
-    const response = await fetch(tokenEndpoint, {
+    const response = await proxyFetch(tokenEndpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',

--- a/src/lib/proxy-utils.ts
+++ b/src/lib/proxy-utils.ts
@@ -128,7 +128,10 @@ export async function initializeProxy(): Promise<void> {
     return initializationPromise;
   }
 
-  initializationPromise = doInitializeProxy();
+  initializationPromise = doInitializeProxy().catch((error) => {
+    initializationPromise = null;
+    throw error;
+  });
   return initializationPromise;
 }
 

--- a/src/lib/proxy-utils.ts
+++ b/src/lib/proxy-utils.ts
@@ -53,6 +53,19 @@ export function isSocksProxy(url: string): boolean {
 }
 
 /**
+ * Redact credentials from proxy URL for safe logging
+ */
+function sanitizeProxyUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.password) parsed.password = '***';
+    return parsed.toString();
+  } catch {
+    return url.replace(/\/\/[^:]+:[^@]+@/, '//***:***@');
+  }
+}
+
+/**
  * Check if URL should bypass proxy based on NO_PROXY/no_proxy env var
  *
  * Supports:
@@ -159,7 +172,7 @@ async function doInitializeProxy(): Promise<void> {
         type: 'pac',
         pacResolver: resolver,
       };
-      logger.info(`PAC proxy initialized from ${pacUrl}`, 'PROXY');
+      logger.info(`PAC proxy initialized from ${sanitizeProxyUrl(pacUrl)}`, 'PROXY');
       return;
     } catch (error) {
       logger.error(`Failed to initialize PAC proxy: ${error}`, 'PROXY');
@@ -170,7 +183,7 @@ async function doInitializeProxy(): Promise<void> {
   const envProxy = detectEnvProxy();
   if (envProxy) {
     proxyConfig = { type: 'env', envProxy };
-    logger.info(`Proxy configured from environment: ${envProxy.url}`, 'PROXY');
+    logger.info(`Proxy configured from environment: ${sanitizeProxyUrl(envProxy.url)}`, 'PROXY');
     return;
   }
 
@@ -214,7 +227,7 @@ export async function getAgentForUrl(url: string): Promise<ProxyAgent | undefine
         const socksMatch = directive.match(/SOCKS5?\s+(\S+):(\d+)/i);
         if (socksMatch) {
           const proxyUrl = `socks5://${socksMatch[1]}:${socksMatch[2]}`;
-          logger.debug(`PAC returned SOCKS proxy for ${url}: ${proxyUrl}`, 'PROXY');
+          logger.debug(`PAC returned SOCKS proxy for ${url}: ${sanitizeProxyUrl(proxyUrl)}`, 'PROXY');
           return new SocksProxyAgent(proxyUrl);
         }
 
@@ -222,7 +235,7 @@ export async function getAgentForUrl(url: string): Promise<ProxyAgent | undefine
         const proxyMatch = directive.match(/PROXY\s+(\S+):(\d+)/i);
         if (proxyMatch) {
           const proxyUrl = `http://${proxyMatch[1]}:${proxyMatch[2]}`;
-          logger.debug(`PAC returned HTTP proxy for ${url}: ${proxyUrl}`, 'PROXY');
+          logger.debug(`PAC returned HTTP proxy for ${url}: ${sanitizeProxyUrl(proxyUrl)}`, 'PROXY');
           return new HttpsProxyAgent(proxyUrl);
         }
       }
@@ -238,7 +251,7 @@ export async function getAgentForUrl(url: string): Promise<ProxyAgent | undefine
   if (proxyConfig.type === 'env' && proxyConfig.envProxy) {
     const { url: proxyUrl, type } = proxyConfig.envProxy;
     try {
-      logger.debug(`Using env proxy ${proxyUrl} for ${url}`, 'PROXY');
+      logger.debug(`Using env proxy ${sanitizeProxyUrl(proxyUrl)} for ${url}`, 'PROXY');
       return type === 'socks'
         ? new SocksProxyAgent(proxyUrl)
         : new HttpsProxyAgent(proxyUrl);

--- a/src/lib/proxy-utils.ts
+++ b/src/lib/proxy-utils.ts
@@ -23,6 +23,7 @@ interface ProxyConfig {
 }
 
 let proxyConfig: ProxyConfig = { type: 'none' };
+let initializationPromise: Promise<void> | null = null;
 
 /**
  * Detect PAC URL from macOS system proxy settings
@@ -31,7 +32,7 @@ function detectMacOsPac(): string | null {
   if (process.platform !== 'darwin') return null;
 
   try {
-    const output = execSync('scutil --proxy', { encoding: 'utf-8' });
+    const output = execSync('scutil --proxy', { encoding: 'utf-8', timeout: 3000 });
     const pacEnabled = output.match(/ProxyAutoConfigEnable\s*:\s*(\d)/)?.[1] === '1';
     const pacUrl = output.match(/ProxyAutoConfigURLString\s*:\s*(\S+)/)?.[1];
 
@@ -42,6 +43,50 @@ function detectMacOsPac(): string | null {
     // scutil failed or not available
   }
   return null;
+}
+
+/**
+ * Check if proxy URL is a SOCKS proxy (case-insensitive)
+ */
+function isSocksProxy(url: string): boolean {
+  return url.toLowerCase().startsWith('socks');
+}
+
+/**
+ * Check if URL should bypass proxy based on NO_PROXY/no_proxy env var
+ *
+ * Supports:
+ * - Single "*" disables proxying for all destinations
+ * - Exact hostname matches (e.g., "example.com")
+ * - Domain suffix matches (e.g., ".example.com" or "example.com" matches "api.example.com")
+ */
+function shouldBypassProxy(targetUrl: string): boolean {
+  const noProxy = process.env.NO_PROXY || process.env.no_proxy;
+  if (!noProxy) return false;
+
+  let hostname: string;
+  try {
+    hostname = new URL(targetUrl).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+
+  const rules = noProxy
+    .split(',')
+    .map((r) => r.trim().toLowerCase())
+    .filter((r) => r.length > 0);
+
+  for (const rule of rules) {
+    if (rule === '*') return true;
+    if (hostname === rule) return true;
+    if (
+      (rule.startsWith('.') && hostname.endsWith(rule)) ||
+      (!rule.startsWith('.') && hostname.endsWith(`.${rule}`))
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -57,17 +102,17 @@ function detectEnvProxy(): { url: string; type: 'socks' | 'http' } | null {
   // Check standard HTTP proxy variables
   const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
   if (httpsProxy) {
-    return { url: httpsProxy, type: httpsProxy.startsWith('socks') ? 'socks' : 'http' };
+    return { url: httpsProxy, type: isSocksProxy(httpsProxy) ? 'socks' : 'http' };
   }
 
   const allProxy = process.env.ALL_PROXY || process.env.all_proxy;
   if (allProxy) {
-    return { url: allProxy, type: allProxy.startsWith('socks') ? 'socks' : 'http' };
+    return { url: allProxy, type: isSocksProxy(allProxy) ? 'socks' : 'http' };
   }
 
   const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
   if (httpProxy) {
-    return { url: httpProxy, type: httpProxy.startsWith('socks') ? 'socks' : 'http' };
+    return { url: httpProxy, type: isSocksProxy(httpProxy) ? 'socks' : 'http' };
   }
 
   return null;
@@ -75,8 +120,22 @@ function detectEnvProxy(): { url: string; type: 'socks' | 'http' } | null {
 
 /**
  * Initialize proxy configuration (call once at startup)
+ * Guards against concurrent initialization calls
  */
 export async function initializeProxy(): Promise<void> {
+  // Return existing promise if initialization is already in progress
+  if (initializationPromise) {
+    return initializationPromise;
+  }
+
+  initializationPromise = doInitializeProxy();
+  return initializationPromise;
+}
+
+/**
+ * Internal initialization logic
+ */
+async function doInitializeProxy(): Promise<void> {
   // 1. Try macOS PAC file first
   const pacUrl = detectMacOsPac();
   if (pacUrl) {
@@ -100,7 +159,7 @@ export async function initializeProxy(): Promise<void> {
       logger.info(`PAC proxy initialized from ${pacUrl}`, 'PROXY');
       return;
     } catch (error) {
-      logger.warn(`Failed to initialize PAC proxy: ${error}`, 'PROXY');
+      logger.error(`Failed to initialize PAC proxy: ${error}`, 'PROXY');
     }
   }
 
@@ -125,33 +184,47 @@ export async function getAgentForUrl(url: string): Promise<ProxyAgent | undefine
     return undefined;
   }
 
+  // Check NO_PROXY before using proxy
+  if (shouldBypassProxy(url)) {
+    logger.debug(`Bypassing proxy for ${url} (matches NO_PROXY)`, 'PROXY');
+    return undefined;
+  }
+
   // PAC-based proxy (macOS)
+  // PAC may return multiple directives separated by semicolons,
+  // e.g. "PROXY p1:8080; PROXY p2:8080; DIRECT"
   if (proxyConfig.type === 'pac' && proxyConfig.pacResolver) {
     try {
       const result = await proxyConfig.pacResolver(url);
+      const directives = result.split(';');
 
-      if (result === 'DIRECT') {
-        logger.debug(`PAC returned DIRECT for ${url}`, 'PROXY');
-        return undefined;
+      for (const rawDirective of directives) {
+        const directive = rawDirective.trim();
+        if (!directive) continue;
+
+        if (directive.toUpperCase() === 'DIRECT') {
+          logger.debug(`PAC returned DIRECT for ${url}`, 'PROXY');
+          return undefined;
+        }
+
+        // Parse "SOCKS host:port" or "SOCKS5 host:port" (case-insensitive)
+        const socksMatch = directive.match(/SOCKS5?\s+(\S+):(\d+)/i);
+        if (socksMatch) {
+          const proxyUrl = `socks5://${socksMatch[1]}:${socksMatch[2]}`;
+          logger.debug(`PAC returned SOCKS proxy for ${url}: ${proxyUrl}`, 'PROXY');
+          return new SocksProxyAgent(proxyUrl);
+        }
+
+        // Parse "PROXY host:port" (case-insensitive)
+        const proxyMatch = directive.match(/PROXY\s+(\S+):(\d+)/i);
+        if (proxyMatch) {
+          const proxyUrl = `http://${proxyMatch[1]}:${proxyMatch[2]}`;
+          logger.debug(`PAC returned HTTP proxy for ${url}: ${proxyUrl}`, 'PROXY');
+          return new HttpsProxyAgent(proxyUrl);
+        }
       }
 
-      // Parse "SOCKS host:port" or "SOCKS5 host:port"
-      const socksMatch = result.match(/SOCKS5?\s+(\S+):(\d+)/);
-      if (socksMatch) {
-        const proxyUrl = `socks5://${socksMatch[1]}:${socksMatch[2]}`;
-        logger.debug(`PAC returned SOCKS proxy for ${url}: ${proxyUrl}`, 'PROXY');
-        return new SocksProxyAgent(proxyUrl);
-      }
-
-      // Parse "PROXY host:port"
-      const proxyMatch = result.match(/PROXY\s+(\S+):(\d+)/);
-      if (proxyMatch) {
-        const proxyUrl = `http://${proxyMatch[1]}:${proxyMatch[2]}`;
-        logger.debug(`PAC returned HTTP proxy for ${url}: ${proxyUrl}`, 'PROXY');
-        return new HttpsProxyAgent(proxyUrl);
-      }
-
-      logger.debug(`PAC returned unknown result for ${url}: ${result}`, 'PROXY');
+      logger.debug(`PAC returned no usable proxy for ${url}: ${result}`, 'PROXY');
     } catch (error) {
       logger.warn(`PAC evaluation failed for ${url}: ${error}`, 'PROXY');
     }
@@ -161,10 +234,15 @@ export async function getAgentForUrl(url: string): Promise<ProxyAgent | undefine
   // Environment variable proxy (all platforms)
   if (proxyConfig.type === 'env' && proxyConfig.envProxy) {
     const { url: proxyUrl, type } = proxyConfig.envProxy;
-    logger.debug(`Using env proxy ${proxyUrl} for ${url}`, 'PROXY');
-    return type === 'socks'
-      ? new SocksProxyAgent(proxyUrl)
-      : new HttpsProxyAgent(proxyUrl);
+    try {
+      logger.debug(`Using env proxy ${proxyUrl} for ${url}`, 'PROXY');
+      return type === 'socks'
+        ? new SocksProxyAgent(proxyUrl)
+        : new HttpsProxyAgent(proxyUrl);
+    } catch (error) {
+      logger.error(`Invalid proxy URL "${proxyUrl}": ${error}`, 'PROXY');
+      return undefined;
+    }
   }
 
   return undefined;

--- a/src/lib/proxy-utils.ts
+++ b/src/lib/proxy-utils.ts
@@ -1,0 +1,185 @@
+/**
+ * Cross-platform proxy utilities for MCP WordPress Remote
+ *
+ * Supports:
+ * - macOS: Automatic PAC file detection from system proxy settings
+ * - All platforms: Environment variables (SOCKS_PROXY, HTTPS_PROXY, etc.)
+ */
+
+import { execSync } from 'child_process';
+import { SocksProxyAgent } from 'socks-proxy-agent';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { logger } from './utils.js';
+
+// Dynamic imports for PAC resolver (has WASM dependencies)
+type PacResolverFn = (url: string) => Promise<string>;
+
+type ProxyAgent = SocksProxyAgent | HttpsProxyAgent<string>;
+
+interface ProxyConfig {
+  type: 'pac' | 'env' | 'none';
+  pacResolver?: PacResolverFn;
+  envProxy?: { url: string; type: 'socks' | 'http' };
+}
+
+let proxyConfig: ProxyConfig = { type: 'none' };
+
+/**
+ * Detect PAC URL from macOS system proxy settings
+ */
+function detectMacOsPac(): string | null {
+  if (process.platform !== 'darwin') return null;
+
+  try {
+    const output = execSync('scutil --proxy', { encoding: 'utf-8' });
+    const pacEnabled = output.match(/ProxyAutoConfigEnable\s*:\s*(\d)/)?.[1] === '1';
+    const pacUrl = output.match(/ProxyAutoConfigURLString\s*:\s*(\S+)/)?.[1];
+
+    if (pacEnabled && pacUrl) {
+      return pacUrl;
+    }
+  } catch {
+    // scutil failed or not available
+  }
+  return null;
+}
+
+/**
+ * Detect proxy from environment variables (cross-platform)
+ */
+function detectEnvProxy(): { url: string; type: 'socks' | 'http' } | null {
+  // Check SOCKS proxy first
+  const socksProxy = process.env.SOCKS_PROXY || process.env.socks_proxy;
+  if (socksProxy) {
+    return { url: socksProxy, type: 'socks' };
+  }
+
+  // Check standard HTTP proxy variables
+  const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+  if (httpsProxy) {
+    return { url: httpsProxy, type: httpsProxy.startsWith('socks') ? 'socks' : 'http' };
+  }
+
+  const allProxy = process.env.ALL_PROXY || process.env.all_proxy;
+  if (allProxy) {
+    return { url: allProxy, type: allProxy.startsWith('socks') ? 'socks' : 'http' };
+  }
+
+  const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
+  if (httpProxy) {
+    return { url: httpProxy, type: httpProxy.startsWith('socks') ? 'socks' : 'http' };
+  }
+
+  return null;
+}
+
+/**
+ * Initialize proxy configuration (call once at startup)
+ */
+export async function initializeProxy(): Promise<void> {
+  // 1. Try macOS PAC file first
+  const pacUrl = detectMacOsPac();
+  if (pacUrl) {
+    try {
+      // Fetch PAC file directly (not through proxy)
+      const response = await fetch(pacUrl);
+      const pacScript = await response.text();
+
+      // Dynamic import for PAC resolver (has WASM dependencies)
+      const { getQuickJS } = await import('@tootallnate/quickjs-emscripten');
+      const { createPacResolver } = await import('pac-resolver');
+
+      // Initialize QuickJS for PAC evaluation
+      const qjs = await getQuickJS();
+      const resolver = createPacResolver(qjs, pacScript);
+
+      proxyConfig = {
+        type: 'pac',
+        pacResolver: resolver,
+      };
+      logger.info(`PAC proxy initialized from ${pacUrl}`, 'PROXY');
+      return;
+    } catch (error) {
+      logger.warn(`Failed to initialize PAC proxy: ${error}`, 'PROXY');
+    }
+  }
+
+  // 2. Try environment variables (all platforms)
+  const envProxy = detectEnvProxy();
+  if (envProxy) {
+    proxyConfig = { type: 'env', envProxy };
+    logger.info(`Proxy configured from environment: ${envProxy.url}`, 'PROXY');
+    return;
+  }
+
+  // 3. No proxy configured
+  logger.debug('No proxy configured', 'PROXY');
+  proxyConfig = { type: 'none' };
+}
+
+/**
+ * Get appropriate agent for a URL based on proxy configuration
+ */
+export async function getAgentForUrl(url: string): Promise<ProxyAgent | undefined> {
+  if (proxyConfig.type === 'none') {
+    return undefined;
+  }
+
+  // PAC-based proxy (macOS)
+  if (proxyConfig.type === 'pac' && proxyConfig.pacResolver) {
+    try {
+      const result = await proxyConfig.pacResolver(url);
+
+      if (result === 'DIRECT') {
+        logger.debug(`PAC returned DIRECT for ${url}`, 'PROXY');
+        return undefined;
+      }
+
+      // Parse "SOCKS host:port" or "SOCKS5 host:port"
+      const socksMatch = result.match(/SOCKS5?\s+(\S+):(\d+)/);
+      if (socksMatch) {
+        const proxyUrl = `socks5://${socksMatch[1]}:${socksMatch[2]}`;
+        logger.debug(`PAC returned SOCKS proxy for ${url}: ${proxyUrl}`, 'PROXY');
+        return new SocksProxyAgent(proxyUrl);
+      }
+
+      // Parse "PROXY host:port"
+      const proxyMatch = result.match(/PROXY\s+(\S+):(\d+)/);
+      if (proxyMatch) {
+        const proxyUrl = `http://${proxyMatch[1]}:${proxyMatch[2]}`;
+        logger.debug(`PAC returned HTTP proxy for ${url}: ${proxyUrl}`, 'PROXY');
+        return new HttpsProxyAgent(proxyUrl);
+      }
+
+      logger.debug(`PAC returned unknown result for ${url}: ${result}`, 'PROXY');
+    } catch (error) {
+      logger.warn(`PAC evaluation failed for ${url}: ${error}`, 'PROXY');
+    }
+    return undefined;
+  }
+
+  // Environment variable proxy (all platforms)
+  if (proxyConfig.type === 'env' && proxyConfig.envProxy) {
+    const { url: proxyUrl, type } = proxyConfig.envProxy;
+    logger.debug(`Using env proxy ${proxyUrl} for ${url}`, 'PROXY');
+    return type === 'socks'
+      ? new SocksProxyAgent(proxyUrl)
+      : new HttpsProxyAgent(proxyUrl);
+  }
+
+  return undefined;
+}
+
+/**
+ * Check if proxy is configured
+ */
+export function isProxyConfigured(): boolean {
+  return proxyConfig.type !== 'none';
+}
+
+/**
+ * Get proxy configuration type for logging
+ */
+export function getProxyType(): 'pac' | 'env' | 'none' {
+  return proxyConfig.type;
+}

--- a/src/lib/proxy-utils.ts
+++ b/src/lib/proxy-utils.ts
@@ -48,7 +48,7 @@ function detectMacOsPac(): string | null {
 /**
  * Check if proxy URL is a SOCKS proxy (case-insensitive)
  */
-function isSocksProxy(url: string): boolean {
+export function isSocksProxy(url: string): boolean {
   return url.toLowerCase().startsWith('socks');
 }
 
@@ -60,7 +60,7 @@ function isSocksProxy(url: string): boolean {
  * - Exact hostname matches (e.g., "example.com")
  * - Domain suffix matches (e.g., ".example.com" or "example.com" matches "api.example.com")
  */
-function shouldBypassProxy(targetUrl: string): boolean {
+export function shouldBypassProxy(targetUrl: string): boolean {
   const noProxy = process.env.NO_PROXY || process.env.no_proxy;
   if (!noProxy) return false;
 
@@ -92,7 +92,7 @@ function shouldBypassProxy(targetUrl: string): boolean {
 /**
  * Detect proxy from environment variables (cross-platform)
  */
-function detectEnvProxy(): { url: string; type: 'socks' | 'http' } | null {
+export function detectEnvProxy(): { url: string; type: 'socks' | 'http' } | null {
   // Check SOCKS proxy first
   const socksProxy = process.env.SOCKS_PROXY || process.env.socks_proxy;
   if (socksProxy) {

--- a/src/lib/wordpress-api.ts
+++ b/src/lib/wordpress-api.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from 'node:events';
 import { WordPressRequestParams, WordPressResponse } from './types.js';
 import { logger, LogLevel } from './utils.js';
 import { CONFIG, validateConfig, getDefaultOAuthScopes, getCustomHeaders } from './config.js';
+import { proxyFetch } from './fetch-utils.js';
 import { WPTokens, AuthError, APIError } from './oauth-types.js';
 import {
   getValidTokens,
@@ -325,7 +326,7 @@ export async function wpRequest(
     logger.api('Sending request to WordPress API...');
     logger.debug(`Request URL: ${url}`, 'API');
     logger.debug(`Request method: ${method}`, 'API');
-    const response = await fetch(url, fetchOptions);
+    const response = await proxyFetch(url, fetchOptions);
     logger.debug(`Response status: ${response.status}`, 'API');
 
     // Handle error responses

--- a/src/types/proxy-deps.d.ts
+++ b/src/types/proxy-deps.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Type declarations for proxy-related dependencies
+ */
+
+declare module '@tootallnate/quickjs-emscripten' {
+  export interface QuickJSWASMModule {
+    // QuickJS WASM module interface
+  }
+
+  export function getQuickJS(): Promise<QuickJSWASMModule>;
+}
+
+declare module 'pac-resolver' {
+  import type { QuickJSWASMModule } from '@tootallnate/quickjs-emscripten';
+
+  export interface PacResolverOptions {
+    filename?: string;
+    sandbox?: Record<string, unknown>;
+  }
+
+  export type FindProxyForURL = (url: string | URL, host?: string) => Promise<string>;
+
+  export function createPacResolver(
+    qjs: QuickJSWASMModule,
+    pacScript: string | Buffer,
+    options?: PacResolverOptions
+  ): FindProxyForURL;
+}

--- a/tests/unit/proxy-utils.test.ts
+++ b/tests/unit/proxy-utils.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Unit tests for proxy utilities
+ */
+
+import { isSocksProxy, shouldBypassProxy, detectEnvProxy } from '../../src/lib/proxy-utils.js';
+import { mockEnv } from '../utils/test-helpers.js';
+
+describe('Proxy Utilities', () => {
+  let restoreEnv: () => void;
+
+  afterEach(() => {
+    if (restoreEnv) {
+      restoreEnv();
+    }
+  });
+
+  describe('isSocksProxy', () => {
+    it('should return true for lowercase socks URLs', () => {
+      expect(isSocksProxy('socks://127.0.0.1:1080')).toBe(true);
+      expect(isSocksProxy('socks4://127.0.0.1:1080')).toBe(true);
+      expect(isSocksProxy('socks5://127.0.0.1:1080')).toBe(true);
+    });
+
+    it('should return true for uppercase SOCKS URLs (case-insensitive)', () => {
+      expect(isSocksProxy('SOCKS://127.0.0.1:1080')).toBe(true);
+      expect(isSocksProxy('SOCKS5://127.0.0.1:1080')).toBe(true);
+      expect(isSocksProxy('Socks5://127.0.0.1:1080')).toBe(true);
+    });
+
+    it('should return false for HTTP proxy URLs', () => {
+      expect(isSocksProxy('http://proxy.example.com:8080')).toBe(false);
+      expect(isSocksProxy('https://proxy.example.com:8080')).toBe(false);
+    });
+
+    it('should return false for non-URL strings', () => {
+      expect(isSocksProxy('proxy.example.com:8080')).toBe(false);
+      expect(isSocksProxy('')).toBe(false);
+    });
+  });
+
+  describe('shouldBypassProxy', () => {
+    it('should return false when NO_PROXY is not set', () => {
+      restoreEnv = mockEnv({});
+      expect(shouldBypassProxy('https://example.com')).toBe(false);
+    });
+
+    it('should match exact hostname', () => {
+      restoreEnv = mockEnv({ NO_PROXY: 'example.com' });
+      expect(shouldBypassProxy('https://example.com/path')).toBe(true);
+      expect(shouldBypassProxy('https://other.com')).toBe(false);
+    });
+
+    it('should match domain suffix without leading dot', () => {
+      restoreEnv = mockEnv({ NO_PROXY: 'example.com' });
+      expect(shouldBypassProxy('https://api.example.com')).toBe(true);
+      expect(shouldBypassProxy('https://deep.api.example.com')).toBe(true);
+      expect(shouldBypassProxy('https://notexample.com')).toBe(false);
+    });
+
+    it('should match domain suffix with leading dot', () => {
+      restoreEnv = mockEnv({ NO_PROXY: '.example.com' });
+      expect(shouldBypassProxy('https://api.example.com')).toBe(true);
+      expect(shouldBypassProxy('https://example.com')).toBe(false); // exact match fails with leading dot
+    });
+
+    it('should handle wildcard (*) to bypass all', () => {
+      restoreEnv = mockEnv({ NO_PROXY: '*' });
+      expect(shouldBypassProxy('https://anything.com')).toBe(true);
+      expect(shouldBypassProxy('https://another.org')).toBe(true);
+    });
+
+    it('should handle multiple comma-separated domains', () => {
+      restoreEnv = mockEnv({ NO_PROXY: 'localhost,example.com,.internal.net' });
+      expect(shouldBypassProxy('https://localhost')).toBe(true);
+      expect(shouldBypassProxy('https://api.example.com')).toBe(true);
+      expect(shouldBypassProxy('https://app.internal.net')).toBe(true);
+      expect(shouldBypassProxy('https://external.com')).toBe(false);
+    });
+
+    it('should handle lowercase no_proxy env var', () => {
+      restoreEnv = mockEnv({ no_proxy: 'example.com' });
+      expect(shouldBypassProxy('https://example.com')).toBe(true);
+    });
+
+    it('should be case-insensitive for hostnames', () => {
+      restoreEnv = mockEnv({ NO_PROXY: 'EXAMPLE.COM' });
+      expect(shouldBypassProxy('https://example.com')).toBe(true);
+      expect(shouldBypassProxy('https://Example.Com')).toBe(true);
+    });
+
+    it('should return false for invalid URLs', () => {
+      restoreEnv = mockEnv({ NO_PROXY: 'example.com' });
+      expect(shouldBypassProxy('not-a-valid-url')).toBe(false);
+      expect(shouldBypassProxy('')).toBe(false);
+    });
+
+    it('should handle whitespace in NO_PROXY', () => {
+      restoreEnv = mockEnv({ NO_PROXY: ' example.com , other.com ' });
+      expect(shouldBypassProxy('https://example.com')).toBe(true);
+      expect(shouldBypassProxy('https://other.com')).toBe(true);
+    });
+  });
+
+  describe('detectEnvProxy', () => {
+    it('should return null when no proxy env vars are set', () => {
+      restoreEnv = mockEnv({});
+      expect(detectEnvProxy()).toBeNull();
+    });
+
+    it('should detect SOCKS_PROXY with socks type', () => {
+      restoreEnv = mockEnv({ SOCKS_PROXY: 'socks5://127.0.0.1:1080' });
+      expect(detectEnvProxy()).toEqual({
+        url: 'socks5://127.0.0.1:1080',
+        type: 'socks',
+      });
+    });
+
+    it('should detect lowercase socks_proxy', () => {
+      restoreEnv = mockEnv({ socks_proxy: 'socks5://127.0.0.1:1080' });
+      expect(detectEnvProxy()).toEqual({
+        url: 'socks5://127.0.0.1:1080',
+        type: 'socks',
+      });
+    });
+
+    it('should detect HTTPS_PROXY with http type', () => {
+      restoreEnv = mockEnv({ HTTPS_PROXY: 'http://proxy.example.com:8080' });
+      expect(detectEnvProxy()).toEqual({
+        url: 'http://proxy.example.com:8080',
+        type: 'http',
+      });
+    });
+
+    it('should detect HTTPS_PROXY with socks:// as socks type', () => {
+      restoreEnv = mockEnv({ HTTPS_PROXY: 'socks5://127.0.0.1:1080' });
+      expect(detectEnvProxy()).toEqual({
+        url: 'socks5://127.0.0.1:1080',
+        type: 'socks',
+      });
+    });
+
+    it('should detect uppercase SOCKS URL in HTTPS_PROXY (case-insensitive)', () => {
+      restoreEnv = mockEnv({ HTTPS_PROXY: 'SOCKS5://127.0.0.1:1080' });
+      expect(detectEnvProxy()).toEqual({
+        url: 'SOCKS5://127.0.0.1:1080',
+        type: 'socks',
+      });
+    });
+
+    it('should detect ALL_PROXY', () => {
+      restoreEnv = mockEnv({ ALL_PROXY: 'http://proxy.example.com:8080' });
+      expect(detectEnvProxy()).toEqual({
+        url: 'http://proxy.example.com:8080',
+        type: 'http',
+      });
+    });
+
+    it('should detect HTTP_PROXY', () => {
+      restoreEnv = mockEnv({ HTTP_PROXY: 'http://proxy.example.com:8080' });
+      expect(detectEnvProxy()).toEqual({
+        url: 'http://proxy.example.com:8080',
+        type: 'http',
+      });
+    });
+
+    it('should prioritize SOCKS_PROXY over HTTPS_PROXY', () => {
+      restoreEnv = mockEnv({
+        SOCKS_PROXY: 'socks5://127.0.0.1:1080',
+        HTTPS_PROXY: 'http://proxy.example.com:8080',
+      });
+      expect(detectEnvProxy()).toEqual({
+        url: 'socks5://127.0.0.1:1080',
+        type: 'socks',
+      });
+    });
+
+    it('should prioritize HTTPS_PROXY over ALL_PROXY', () => {
+      restoreEnv = mockEnv({
+        HTTPS_PROXY: 'http://https-proxy.example.com:8080',
+        ALL_PROXY: 'http://all-proxy.example.com:8080',
+      });
+      expect(detectEnvProxy()).toEqual({
+        url: 'http://https-proxy.example.com:8080',
+        type: 'http',
+      });
+    });
+
+    it('should prioritize ALL_PROXY over HTTP_PROXY', () => {
+      restoreEnv = mockEnv({
+        ALL_PROXY: 'http://all-proxy.example.com:8080',
+        HTTP_PROXY: 'http://http-proxy.example.com:8080',
+      });
+      expect(detectEnvProxy()).toEqual({
+        url: 'http://all-proxy.example.com:8080',
+        type: 'http',
+      });
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "resolveJsonModule": true,
     "declaration": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "src/types/**/*.d.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Adds optional system proxy support via the `USE_SYSTEM_PROXY` environment variable.

When enabled, the server automatically detects and routes HTTP requests through system-configured proxies (PAC files on macOS, environment variables on all platforms).

## Why

Node.js doesn't respect system proxy settings by default.

## How

New `USE_SYSTEM_PROXY` config option (default: `false`) with cross-platform proxy detection.

- **macOS**: Reads PAC URL from system settings via `scutil --proxy`, fetches and evaluates the PAC file using QuickJS WASM
- **All platforms**: Falls back to environment variables (`SOCKS_PROXY`, `HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`)
- New `proxyFetch()` wrapper that routes requests through detected proxies
- All fetch calls updated to use `proxyFetch()`

## Testing Steps

1. Build the project: `npm run build`

2. Test with proxy disabled (default):
   ```bash
   node --input-type=module -e "
     import { setupFetchPolyfill, proxyFetch, getProxyInfo } from './dist/lib.js';
     await setupFetchPolyfill();
     console.log('Proxy:', getProxyInfo());
     const r = await proxyFetch('https://en.wordpress.com/whatismyip?basic');
     console.log('IP:', (await r.text()).trim());
   "
   ```
   Expected: `Proxy: { configured: false, type: 'none' }` and your direct IP

3. Test with proxy enabled (macOS with system proxy configured):
   ```bash
   USE_SYSTEM_PROXY=true node --input-type=module -e "
     import { setupFetchPolyfill, proxyFetch, getProxyInfo } from './dist/lib.js';
     await setupFetchPolyfill();
     console.log('Proxy:', getProxyInfo());
     const r = await proxyFetch('https://en.wordpress.com/whatismyip?basic');
     console.log('IP:', (await r.text()).trim());
   "
   ```
   Expected: `Proxy: { configured: true, type: 'pac' }` and proxy IP

4. Test with env var proxy (disable AutoProxxyl):
   ```bash
   USE_SYSTEM_PROXY=true SOCKS_PROXY=socks5://127.0.0.1:8080 node --input-type=module -e "
     import { setupFetchPolyfill, proxyFetch, getProxyInfo } from './dist/lib.js';
     await setupFetchPolyfill();
     console.log('Proxy:', getProxyInfo());
   "
   ```
   Expected: `Proxy: { configured: true, type: 'env' }`
