### PR TITLE
Bump version to 0.2.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/mcp-wordpress-remote",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
         "@tootallnate/quickjs-emscripten": "^0.23.0",
@@ -15,7 +15,6 @@
         "node-fetch": "^3.3.2",
         "open": "^10.0.0",
         "pac-resolver": "^7.0.1",
-        "quickjs-emscripten": "^0.31.0",
         "socks-proxy-agent": "^8.0.5"
       },
       "bin": {
@@ -1389,48 +1388,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jitl/quickjs-ffi-types": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@jitl/quickjs-ffi-types/-/quickjs-ffi-types-0.31.0.tgz",
-      "integrity": "sha512-1yrgvXlmXH2oNj3eFTrkwacGJbmM0crwipA3ohCrjv52gBeDaD7PsTvFYinlAnqU8iPME3LGP437yk05a2oejw==",
-      "license": "MIT"
-    },
-    "node_modules/@jitl/quickjs-wasmfile-debug-asyncify": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-debug-asyncify/-/quickjs-wasmfile-debug-asyncify-0.31.0.tgz",
-      "integrity": "sha512-YkdzQdr1uaftFhgEnTRjTTZHk2SFZdpWO7XhOmRVbi6CEVsH9g5oNF8Ta1q3OuSJHRwwT8YsuR1YzEiEIJEk6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@jitl/quickjs-ffi-types": "0.31.0"
-      }
-    },
-    "node_modules/@jitl/quickjs-wasmfile-debug-sync": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-debug-sync/-/quickjs-wasmfile-debug-sync-0.31.0.tgz",
-      "integrity": "sha512-8XvloaaWBONqcHXYs5tWOjdhQVxzULilIfB2hvZfS6S+fI4m2+lFiwQy7xeP8ExHmiZ7D8gZGChNkdLgjGfknw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jitl/quickjs-ffi-types": "0.31.0"
-      }
-    },
-    "node_modules/@jitl/quickjs-wasmfile-release-asyncify": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-release-asyncify/-/quickjs-wasmfile-release-asyncify-0.31.0.tgz",
-      "integrity": "sha512-uz0BbQYTxNsFkvkurd7vk2dOg57ElTBLCuvNtRl4rgrtbC++NIndD5qv2+AXb6yXDD3Uy1O2PCwmoaH0eXgEOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jitl/quickjs-ffi-types": "0.31.0"
-      }
-    },
-    "node_modules/@jitl/quickjs-wasmfile-release-sync": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-release-sync/-/quickjs-wasmfile-release-sync-0.31.0.tgz",
-      "integrity": "sha512-hYduecOByj9AsAfsJhZh5nA6exokmuFC8cls39+lYmTCGY51bgjJJJwReEu7Ff7vBWaQCL6TeDdVlnp2WYz0jw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jitl/quickjs-ffi-types": "0.31.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -6210,31 +6167,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/quickjs-emscripten": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/quickjs-emscripten/-/quickjs-emscripten-0.31.0.tgz",
-      "integrity": "sha512-K7Yt78aRPLjPcqv3fIuLW1jW3pvwO21B9pmFOolsjM/57ZhdVXBr51GqJpalgBlkPu9foAvhEAuuQPnvIGvLvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jitl/quickjs-wasmfile-debug-asyncify": "0.31.0",
-        "@jitl/quickjs-wasmfile-debug-sync": "0.31.0",
-        "@jitl/quickjs-wasmfile-release-asyncify": "0.31.0",
-        "@jitl/quickjs-wasmfile-release-sync": "0.31.0",
-        "quickjs-emscripten-core": "0.31.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/quickjs-emscripten-core": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/quickjs-emscripten-core/-/quickjs-emscripten-core-0.31.0.tgz",
-      "integrity": "sha512-oQz8p0SiKDBc1TC7ZBK2fr0GoSHZKA0jZIeXxsnCyCs4y32FStzCW4d1h6E1sE0uHDMbGITbk2zhNaytaoJwXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jitl/quickjs-ffi-types": "0.31.0"
       }
     },
     "node_modules/range-parser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "MCP WordPress Remote proxy server",
   "engines": {
     "node": ">=18.0.0"

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,7 +4,7 @@ import { selectCallbackPort } from './port-utils.js';
 import { logger } from './utils.js';
 
 // Version constant - update this manually when releasing new versions
-export const MCP_WORDPRESS_REMOTE_VERSION = '0.2.18';
+export const MCP_WORDPRESS_REMOTE_VERSION = '0.2.19';
 
 /**
  * Centralized configuration for MCP WordPress Remote

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,6 +9,7 @@ import { setupFetchPolyfill } from './lib/fetch-utils.js';
 import { detectTransportType } from './lib/transport-detection.js';
 import { createSessionContext } from './lib/session-utils.js';
 import { createWrappedHandler, HANDLER_CONFIGS } from './lib/request-handler-factory.js';
+import { MCP_WORDPRESS_REMOTE_VERSION } from './lib/config.js';
 import {
   CallToolRequestSchema,
   ListResourcesRequestSchema,
@@ -70,7 +71,7 @@ async function WordPressProxy() {
   const server = new Server(
     {
       name: 'WordPress MCP Remote Proxy',
-      version: '0.2.17',
+      version: MCP_WORDPRESS_REMOTE_VERSION,
     },
     {
       capabilities: {
@@ -113,7 +114,7 @@ async function WordPressProxy() {
         protocolVersion: '2025-06-18',
         serverInfo: {
           name: 'WordPress MCP Remote Proxy',
-          version: '0.2.17',
+          version: MCP_WORDPRESS_REMOTE_VERSION,
         },
         capabilities: {
           tools: {},

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -138,7 +138,7 @@ describe('Configuration Module', () => {
       const result = validateConfig();
 
       expect(result.isValid).toBe(false);
-      expect(result.errors.some(error => error.includes('No authentication method configured. Please set one of: JWT_TOKEN, WP_API_USERNAME+WP_API_PASSWORD, or enable OAuth'))).toBe(true);
+      expect(result.errors.some(error => error.includes('No authentication method configured'))).toBe(true);
     });
   });
 
@@ -274,7 +274,7 @@ describe('Configuration Module', () => {
       const status = getConfigHealthStatus();
 
       expect(status.status).toBe('healthy');
-      expect(status.version).toBe('0.2.9');
+      expect(status.version).toBe('0.2.19');
       expect(status.uptime).toBeGreaterThan(0);
       expect(status.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
     });

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -50,7 +50,7 @@ describe('Utils Module', () => {
     it('should export version constant', async () => {
       const { MCP_WORDPRESS_REMOTE_VERSION } = await import('../../src/lib/utils.js');
       
-      expect(MCP_WORDPRESS_REMOTE_VERSION).toBe('0.2.1');
+      expect(MCP_WORDPRESS_REMOTE_VERSION).toBe('0.2.19');
     });
   });
 


### PR DESCRIPTION
Prepares the 0.2.19 release which includes the proxy support added in #40. Also fixes hardcoded version strings in src/proxy.ts so they stay in sync with the central version constant going forward.