### PR TITLE
Fix race condition: tools/list sent without JSON-RPC envelope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# mcp-wordpress-remote
+
+MCP proxy server between Claude Code and a WordPress backend.
+
+## Commit discipline
+
+**Every line in a commit must trace to the stated goal.** No drive-by cleanups, no unrelated "improvements." The 0.2.20 race condition was caused by a harmless-looking capabilities change (`tools: {}` → `tools: { listChanged: false }`) bundled with an unrelated SOCKS proxy fix. Review every changed line — if it isn't required for the task, remove it before committing.
+
+## Pre-publish release gate
+
+"Works in repo" is not enough. Gate on "works from packed artifact in clean environment."
+
+1. Build and pack: `npm ci && npm run build && npm pack`
+2. Install tarball in a clean temp dir, run `npx mcp-wordpress-remote --help`
+3. Test against a healthy WordPress endpoint (normal init + tools/list flow)
+4. Test against a broken endpoint (fallback init, no malformed forwarding)
+5. Debug logs: verify no forwarded requests fire before init settles
+6. Publish canary first (`x.y.z-canary.1`), soak in real clients, then promote to latest
+7. Know the last good version — be ready for immediate dist-tag rollback
+
+## Testing
+
+- Run all tests: `npx jest tests/unit/ --no-coverage`
+- Build: `npm run build`
+- ESM mocking pattern: set `process.env` vars BEFORE `jest.resetModules()` + dynamic imports (CONFIG caches at import time)
+- WordPress API endpoint in nock: `/?rest_route=/wp/v2/wpmcp` (not `/wp/v2/wpmcp`)
+
+## Architecture notes
+
+- Transport detection (JSON-RPC vs simple) runs during the `initialize` handler
+- `sessionContext.transportType` starts null — the init-ready gate (`waitForInit`) blocks all handlers until detection settles
+- `waitForInit` returns `InitResult` (`{ ready: true } | { ready: false; reason: 'failed' | 'timeout' }`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.2.19",
+  "version": "0.2.21",
   "description": "MCP WordPress Remote proxy server",
   "engines": {
     "node": ">=18.0.0"

--- a/src/lib/request-handler-factory.ts
+++ b/src/lib/request-handler-factory.ts
@@ -8,7 +8,7 @@ import { logger } from './utils.js';
 import { wpRequest } from './wordpress-api.js';
 import { isAPIError } from './oauth-types.js';
 import { convertAPIErrorToMcpError } from './error-utils.js';
-import { prepareRequest, SessionContext } from './session-utils.js';
+import { prepareRequest, waitForInit, SessionContext } from './session-utils.js';
 import { WPRequestParams } from './mcp-types.js';
 
 /**
@@ -26,16 +26,23 @@ export interface HandlerConfig {
 export function createRequestHandler(config: HandlerConfig, context: SessionContext) {
   return async (request: any) => {
     logger.debug(`Processing ${config.name}Request`, 'MCP');
-    
+
+    // Wait for transport detection to complete before forwarding any requests
+    const init = await waitForInit(context);
+    if (!init.ready) {
+      const cause = init.reason === 'timeout' ? 'timed out waiting for' : 'failed during';
+      throw new Error(`Cannot process ${config.method}: WordPress connection ${cause} initialization`);
+    }
+
     // Map request parameters to WordPress format
     const wpParams = config.paramMapper(request);
-    
+
     // Prepare request based on transport type
     const requestData = prepareRequest(wpParams, request, context);
-    
+
     // Send request to WordPress
     const response = await wpRequest(requestData, context.transportType === 'jsonrpc');
-    
+
     return response;
   };
 }

--- a/src/lib/session-utils.ts
+++ b/src/lib/session-utils.ts
@@ -1,6 +1,6 @@
 /**
  * Session and Request Utilities for MCP WordPress Remote
- * 
+ *
  * Provides utilities for session management and request preparation
  */
 
@@ -14,13 +14,20 @@ export interface SessionContext {
   sessionId: string | null;
   requestIdCounter: number;
   transportType: TransportType;
+  /** @internal Managed by resolveInit/waitForInit — do not access directly. */
+  _init: {
+    ready: Promise<void>;
+    resolve: () => void;
+    settled: boolean;
+    failed: boolean;
+  };
 }
 
 /**
  * Add session information to WordPress requests and format as JSON-RPC
  */
 export function addSessionInfo(
-  wpRequestParams: WPRequestParams, 
+  wpRequestParams: WPRequestParams,
   mcpRequest: MCPRequest,
   context: SessionContext
 ) {
@@ -55,7 +62,7 @@ export function addSessionInfo(
  * Prepare request based on transport type
  */
 export function prepareRequest(
-  wpRequestParams: WPRequestParams, 
+  wpRequestParams: WPRequestParams,
   mcpRequest: MCPRequest,
   context: SessionContext
 ) {
@@ -72,9 +79,60 @@ export function prepareRequest(
  * Create a new session context
  */
 export function createSessionContext(): SessionContext {
+  let resolve: () => void;
+  const ready = new Promise<void>(r => { resolve = r; });
+
   return {
     sessionId: null,
     requestIdCounter: 0,
     transportType: null,
+    _init: {
+      ready,
+      resolve: resolve!,
+      settled: false,
+      failed: false,
+    },
   };
+}
+
+/**
+ * Signal that initialization completed (success or failure).
+ * Unblocks all handlers waiting on waitForInit.
+ */
+export function resolveInit(context: SessionContext, failed: boolean): void {
+  if (context._init.settled) return;
+  context._init.failed = failed;
+  context._init.settled = true;
+  context._init.resolve();
+}
+
+/** Default timeout for waiting on init (30s matches the MCP SDK's default request timeout). */
+const INIT_TIMEOUT_MS = 30_000;
+
+/**
+ * Wait for initialization to complete before handling a request.
+ * Returns true if the connection is ready, false if init failed or timed out.
+ */
+export type InitResult = { ready: true } | { ready: false; reason: 'failed' | 'timeout' };
+
+export async function waitForInit(context: SessionContext, timeoutMs = INIT_TIMEOUT_MS): Promise<InitResult> {
+  // Fast path: init already settled, no async work needed
+  if (context._init.settled) {
+    return context._init.failed ? { ready: false, reason: 'failed' } : { ready: true };
+  }
+
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<'timeout'>(resolve => {
+    timer = setTimeout(() => resolve('timeout'), timeoutMs);
+  });
+
+  const result = await Promise.race([context._init.ready.then(() => 'ready' as const), timeout]);
+  clearTimeout(timer!);
+
+  if (result === 'timeout') {
+    logger.error('Timed out waiting for initialization to complete', 'INIT');
+    return { ready: false, reason: 'timeout' };
+  }
+
+  return context._init.failed ? { ready: false, reason: 'failed' } : { ready: true };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,7 +7,7 @@ import { cleanupExpiredTokens } from './lib/persistent-auth-config.js';
 import { validateNodeVersion } from './lib/node-utils.js';
 import { setupFetchPolyfill } from './lib/fetch-utils.js';
 import { detectTransportType } from './lib/transport-detection.js';
-import { createSessionContext } from './lib/session-utils.js';
+import { createSessionContext, resolveInit } from './lib/session-utils.js';
 import { createWrappedHandler, HANDLER_CONFIGS } from './lib/request-handler-factory.js';
 import { MCP_WORDPRESS_REMOTE_VERSION } from './lib/config.js';
 import {
@@ -92,6 +92,9 @@ async function WordPressProxy() {
       logger.info('🔄 Initializing WordPress connection with client parameters', 'INIT');
       const { initResult } = await detectTransportType(sessionContext, request.params);
 
+      // Signal that init is complete — unblocks any handlers waiting on waitForInit
+      resolveInit(sessionContext, false);
+
       // Return the WordPress server's initialize response
       const wordpressInitResponse = {
         protocolVersion: initResult.protocolVersion || '2025-06-18',
@@ -111,9 +114,13 @@ async function WordPressProxy() {
         error
       );
 
+      // Mark init as failed and unblock waiting handlers (they'll return errors)
+      resolveInit(sessionContext, true);
+
       const clientProtocolVersion = request?.params?.protocolVersion || '2025-06-18';
 
-      // Return a basic fallback response
+      // Return a fallback response with empty capabilities so the SDK
+      // doesn't try to list tools/resources/prompts for a dead connection
       const fallbackResponse = {
         protocolVersion: clientProtocolVersion,
         serverInfo: {
@@ -121,16 +128,9 @@ async function WordPressProxy() {
           version: MCP_WORDPRESS_REMOTE_VERSION,
         },
         capabilities: {
-          tools: {
-            listChanged: false,
-          },
-          resources: {
-            listChanged: false,
-            subscribe: false,
-          },
-          prompts: {
-            listChanged: false,
-          },
+          tools: {},
+          resources: {},
+          prompts: {},
           logging: {},
           completions: {},
         },

--- a/tests/integration/dead-backend.test.ts
+++ b/tests/integration/dead-backend.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Integration test: dead backend regression
+ *
+ * Spawns the actual proxy as a child process, sends MCP messages over stdio,
+ * and verifies the exact failure path from the 0.2.20 race condition:
+ *
+ *   1. Client sends initialize → proxy tries to reach WordPress → fails
+ *   2. Proxy returns fallback init with empty capabilities
+ *   3. Client sends tools/list anyway → proxy returns clean MCP error
+ *      (NOT a malformed request forwarded to a dead backend)
+ *
+ * This is a true end-to-end smoke test: it exercises the built artifact
+ * (dist/proxy.js), not source imports.
+ */
+
+import { spawn, ChildProcess } from 'child_process';
+import { once } from 'events';
+import { join } from 'path';
+
+const PROXY_PATH = join(process.cwd(), 'dist/proxy.js');
+
+/** Send a JSON-RPC message to the proxy's stdin (newline-delimited). */
+function send(proc: ChildProcess, message: object): void {
+  proc.stdin!.write(JSON.stringify(message) + '\n');
+}
+
+/**
+ * Collect newline-delimited JSON messages from stdout until we have `count` of them,
+ * or timeout after `ms` milliseconds.
+ */
+function collectMessages(proc: ChildProcess, count: number, ms = 15_000): Promise<any[]> {
+  return new Promise((resolve, reject) => {
+    const messages: any[] = [];
+    let buffer = '';
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out after ${ms}ms waiting for ${count} message(s), got ${messages.length}: ${JSON.stringify(messages)}`));
+    }, ms);
+
+    function onData(chunk: Buffer) {
+      buffer += chunk.toString();
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newline).trim();
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        try {
+          messages.push(JSON.parse(line));
+        } catch {
+          // skip non-JSON lines (e.g. log output leaked to stdout)
+        }
+        if (messages.length >= count) {
+          cleanup();
+          resolve(messages);
+          return;
+        }
+      }
+    }
+
+    function cleanup() {
+      clearTimeout(timer);
+      proc.stdout!.off('data', onData);
+    }
+
+    proc.stdout!.on('data', onData);
+  });
+}
+
+describe('dead backend integration', () => {
+  let proxy: ChildProcess;
+
+  afterEach(() => {
+    if (proxy && !proxy.killed) {
+      proxy.kill();
+    }
+  });
+
+  it('returns fallback init and rejects tools/list when WordPress is unreachable', async () => {
+    // Spawn the built proxy pointed at a host that will never connect.
+    // Using 192.0.2.1 (TEST-NET, RFC 5737) — guaranteed unroutable, no DNS lookup.
+    proxy = spawn('node', [PROXY_PATH], {
+      env: {
+        ...process.env,
+        WP_API_URL: 'http://192.0.2.1:1',
+        JWT_TOKEN: 'test-dead-backend-token',
+        LOG_LEVEL: '0',     // suppress logs on stderr
+        NODE_ENV: 'test',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    // Drain stderr so the child doesn't block
+    proxy.stderr!.resume();
+
+    // Wait for the process to be ready (give it a moment to boot)
+    await new Promise(r => setTimeout(r, 200));
+
+    // 1. Send initialize
+    send(proxy, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        clientInfo: { name: 'dead-backend-test', version: '1.0.0' },
+        capabilities: {},
+      },
+    });
+
+    // Collect the initialize response
+    const [initResponse] = await collectMessages(proxy, 1);
+
+    expect(initResponse).toHaveProperty('jsonrpc', '2.0');
+    expect(initResponse).toHaveProperty('id', 1);
+    expect(initResponse.result).toBeDefined();
+
+    // Fallback response should have empty capabilities (no tools to list)
+    const caps = initResponse.result.capabilities;
+    expect(caps.tools).toEqual({});
+    expect(caps.resources).toEqual({});
+    expect(caps.prompts).toEqual({});
+
+    // Instructions should indicate failure
+    expect(initResponse.result.instructions).toMatch(/Connection Failed/i);
+
+    // 2. Send initialized notification (required by MCP protocol before requests)
+    send(proxy, {
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    });
+
+    // 3. Send tools/list — this is the exact request that triggered the 0.2.20 bug
+    send(proxy, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+      params: {},
+    });
+
+    // Collect the tools/list response
+    const [toolsResponse] = await collectMessages(proxy, 1);
+
+    expect(toolsResponse).toHaveProperty('jsonrpc', '2.0');
+    expect(toolsResponse).toHaveProperty('id', 2);
+
+    // The response must be a clean MCP error, NOT a forwarded malformed request.
+    // The init-ready gate should have caught this and returned an error.
+    expect(toolsResponse.error).toBeDefined();
+    expect(toolsResponse.error.message).toMatch(/WordPress connection failed during initialization/);
+  }, 30_000);
+
+  // Healthy-backend integration test omitted: unit tests cover the happy path.
+  // A full test here needs a real or mocked WordPress endpoint in the child process.
+});

--- a/tests/integration/simple-integration.test.ts
+++ b/tests/integration/simple-integration.test.ts
@@ -1,206 +1,31 @@
 /**
- * Simple integration tests for core functionality
+ * Integration tests for cross-module behavior not covered by unit tests.
+ *
+ * Most of the original tests here were duplicates of unit-level coverage
+ * in config.test.ts, mcp-oauth-utils.test.ts, and utils.test.ts.
+ * Only tests that exercise behavior unique to module integration remain.
  */
 
 import { jest } from '@jest/globals';
-import nock from 'nock';
-import { mockEnv, createTempDir, cleanupTempDir } from '../utils/test-helpers.js';
-import { createMockToken } from '../utils/mock-factories.js';
 
 describe('Core Integration Tests', () => {
-  let restoreEnv: () => void;
-  let tempDir: string;
-
-  beforeEach(async () => {
-    tempDir = await createTempDir();
-    
-    restoreEnv = mockEnv({
-      WP_API_URL: 'https://test-site.com',
-      WP_OAUTH_CLIENT_ID: 'test_client_id',
-      WP_OAUTH_CLIENT_SECRET: 'test_client_secret',
-      OAUTH_ENABLED: 'true',
-      WP_MCP_CONFIG_DIR: tempDir,
-      NODE_ENV: 'test',
-    });
-
+  beforeEach(() => {
     jest.resetModules();
-    nock.cleanAll();
   });
 
-  afterEach(async () => {
-    nock.cleanAll();
-    if (restoreEnv) {
-      restoreEnv();
-    }
-    await cleanupTempDir(tempDir);
-  });
-
-  describe('Configuration Integration', () => {
-    it('should validate complete configuration setup', async () => {
-      const { validateConfig, CONFIG } = await import('../../src/lib/config.js');
-      
-      const result = validateConfig();
-      
-      expect(result.isValid).toBe(true);
-      expect(CONFIG.WP_API_URL).toBe('https://test-site.com');
-      expect(CONFIG.OAUTH_ENABLED).toBe(true);
-    });
-
-    it('should provide default OAuth scopes', async () => {
-      const { getDefaultOAuthScopes } = await import('../../src/lib/config.js');
-      
-      const scopes = getDefaultOAuthScopes();
-      expect(scopes).toEqual(['read', 'write']);
-    });
-  });
-
-  describe('OAuth Utils Integration', () => {
-    it('should generate valid PKCE data for OAuth 2.1', async () => {
-      const { generatePKCE, generateSecureState } = await import('../../src/lib/mcp-oauth-utils.js');
-      
-      const pkce = generatePKCE();
-      const state = generateSecureState();
-      
-      expect(pkce.codeVerifier).toBeTruthy();
-      expect(pkce.codeChallenge).toBeTruthy();
-      expect(pkce.codeChallengeMethod).toBe('S256');
-      expect(state).toBeTruthy();
-      expect(state.length).toBeGreaterThan(20);
-    });
-
-    it('should build complete authorization URLs', async () => {
-      const { buildAuthorizationUrl, generatePKCE, generateSecureState } = await import('../../src/lib/mcp-oauth-utils.js');
-      
-      const pkce = generatePKCE();
-      const state = generateSecureState();
-      
-      const url = buildAuthorizationUrl(
-        'https://public-api.wordpress.com/oauth2/authorize',
-        'test_client_id',
-        'http://localhost:3000/callback',
-        ['global'],
-        state,
-        pkce.codeChallenge
-      );
-      
-      const urlObj = new URL(url);
-      expect(urlObj.searchParams.get('response_type')).toBe('code');
-      expect(urlObj.searchParams.get('client_id')).toBe('test_client_id');
-      expect(urlObj.searchParams.get('code_challenge')).toBe(pkce.codeChallenge);
-      expect(urlObj.searchParams.get('code_challenge_method')).toBe('S256');
-    });
-
-    it('should parse WWW-Authenticate headers correctly', async () => {
-      const { parseWWWAuthenticateHeader } = await import('../../src/lib/mcp-oauth-utils.js');
-      
-      const header = 'Bearer realm="WordPress API", error="invalid_token", error_description="Token expired"';
-      const parsed = parseWWWAuthenticateHeader(header);
-      
-      expect(parsed.scheme).toBe('Bearer');
-      expect(parsed.realm).toBe('WordPress API');
-      expect(parsed.error).toBe('invalid_token');
-      expect(parsed.error_description).toBe('Token expired');
-    });
-  });
-
-  describe('OAuth Callback Server Integration', () => {
-    it('should import OAuth callback server classes', async () => {
-      const { OAuthCallbackServer } = await import('../../src/lib/oauth-callback-server.js');
-      
-      // Test that the class is importable and is a constructor
-      expect(typeof OAuthCallbackServer).toBe('function');
-      expect(OAuthCallbackServer.name).toBe('OAuthCallbackServer');
-    });
-  });
-
-  describe('OAuth Types and Error Handling', () => {
-    it('should handle OAuth errors correctly', async () => {
+  describe('Custom error classes', () => {
+    it('AuthError and APIError carry structured context for callers', async () => {
       const { AuthError, APIError } = await import('../../src/lib/oauth-types.js');
-      
+
       const authError = new AuthError('Invalid credentials', 'INVALID_CREDENTIALS');
-      const apiError = new APIError('API request failed', 500, '/test/endpoint');
-      
+      expect(authError).toBeInstanceOf(Error);
       expect(authError.message).toBe('Invalid credentials');
+
+      const apiError = new APIError('API request failed', 500, '/test/endpoint');
+      expect(apiError).toBeInstanceOf(Error);
       expect(apiError.statusCode).toBe(500);
       expect(apiError.endpoint).toBe('/test/endpoint');
       expect(apiError.message).toBe('API request failed');
-    });
-  });
-
-  describe('Utility Functions Integration', () => {
-    it('should integrate logging functionality', async () => {
-      const { logger } = await import('../../src/lib/utils.js');
-      
-      // Test that logger methods exist and can be called
-      expect(typeof logger.info).toBe('function');
-      expect(typeof logger.error).toBe('function');
-      expect(typeof logger.debug).toBe('function');
-      
-      // These should not throw
-      logger.info('Test info message', 'TEST');
-      logger.error('Test error message', 'TEST');
-      logger.debug('Test debug message', 'TEST');
-    });
-  });
-
-  describe('Module Integration', () => {
-    it('should import all core modules without errors', async () => {
-      // Test that all modules can be imported without throwing
-      await expect(import('../../src/lib/config.js')).resolves.toBeDefined();
-      await expect(import('../../src/lib/mcp-oauth-utils.js')).resolves.toBeDefined();
-      await expect(import('../../src/lib/oauth-types.js')).resolves.toBeDefined();
-      await expect(import('../../src/lib/utils.js')).resolves.toBeDefined();
-      await expect(import('../../src/lib/oauth-callback-server.js')).resolves.toBeDefined();
-    });
-
-    it('should have consistent TypeScript interfaces', async () => {
-      const mockToken = createMockToken();
-      
-      // Mock token should conform to WPTokens interface structure
-      expect(mockToken).toHaveProperty('access_token');
-      expect(mockToken).toHaveProperty('token_type');
-      expect(mockToken).toHaveProperty('obtained_at');
-      expect(typeof mockToken.access_token).toBe('string');
-      expect(typeof mockToken.token_type).toBe('string');
-      expect(typeof mockToken.obtained_at).toBe('number');
-    });
-  });
-
-  describe('Environment Configuration Integration', () => {
-    it('should handle different environment configurations', async () => {
-      // Test production-like configuration
-      restoreEnv();
-      restoreEnv = mockEnv({
-        WP_API_URL: 'https://production-site.com',
-        WP_OAUTH_CLIENT_ID: 'prod_client_id',
-        OAUTH_ENABLED: 'true',
-        NODE_ENV: 'production',
-        WP_MCP_CONFIG_DIR: tempDir,
-      });
-
-      const { CONFIG, validateConfig } = await import('../../src/lib/config.js');
-      
-      expect(CONFIG.NODE_ENV).toBe('production');
-      expect(CONFIG.WP_API_URL).toBe('https://production-site.com');
-      
-      const validation = validateConfig();
-      expect(validation.isValid).toBe(true);
-    });
-
-    it('should handle development configuration', async () => {
-      restoreEnv();
-      restoreEnv = mockEnv({
-        WP_API_URL: 'http://localhost:8080',
-        WP_OAUTH_CLIENT_ID: 'dev_client_id',
-        OAUTH_ENABLED: 'true',
-        NODE_ENV: 'development',
-        WP_MCP_CONFIG_DIR: tempDir,
-      });
-
-      const { CONFIG } = await import('../../src/lib/config.js');
-      
-      expect(CONFIG.NODE_ENV).toBe('development');
-      expect(CONFIG.WP_API_URL).toBe('http://localhost:8080');
     });
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -5,131 +5,12 @@
 
 import { jest } from '@jest/globals';
 
-// Extend Jest matchers for OAuth and API testing
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toBeValidOAuthToken(): R;
-      toBeExpiredToken(): R;
-      toHaveValidSignature(): R;
-      toBeValidWordPressResponse(): R;
-      toMatchMCPSchema(): R;
-    }
-  }
-}
-
-// Custom matcher for OAuth token validation
-expect.extend({
-  toBeValidOAuthToken(received: any) {
-    const pass = received &&
-      typeof received.access_token === 'string' &&
-      received.access_token.length > 0 &&
-      typeof received.token_type === 'string' &&
-      typeof received.obtained_at === 'number' &&
-      received.obtained_at > 0;
-
-    if (pass) {
-      return {
-        message: () => `expected ${JSON.stringify(received)} not to be a valid OAuth token`,
-        pass: true,
-      };
-    } else {
-      return {
-        message: () => `expected ${JSON.stringify(received)} to be a valid OAuth token with access_token, token_type, and obtained_at`,
-        pass: false,
-      };
-    }
-  },
-
-  toBeExpiredToken(received: any) {
-    if (!received || typeof received.obtained_at !== 'number' || typeof received.expires_in !== 'number') {
-      return {
-        message: () => `expected ${JSON.stringify(received)} to have obtained_at and expires_in properties`,
-        pass: false,
-      };
-    }
-
-    const now = Date.now();
-    const expiryTime = received.obtained_at + (received.expires_in * 1000);
-    const pass = expiryTime < now;
-
-    if (pass) {
-      return {
-        message: () => `expected token not to be expired`,
-        pass: true,
-      };
-    } else {
-      return {
-        message: () => `expected token to be expired`,
-        pass: false,
-      };
-    }
-  },
-
-  toHaveValidSignature(received: any) {
-    const pass = received &&
-      typeof received === 'string' &&
-      received.length === 64 && // SHA-256 hex string
-      /^[a-f0-9]+$/.test(received);
-
-    if (pass) {
-      return {
-        message: () => `expected ${received} not to be a valid SHA-256 signature`,
-        pass: true,
-      };
-    } else {
-      return {
-        message: () => `expected ${received} to be a valid SHA-256 signature (64 char hex string)`,
-        pass: false,
-      };
-    }
-  },
-
-  toBeValidWordPressResponse(received: any) {
-    const pass = received &&
-      typeof received === 'object' &&
-      received.status !== undefined &&
-      (received.data !== undefined || received.error !== undefined);
-
-    if (pass) {
-      return {
-        message: () => `expected ${JSON.stringify(received)} not to be a valid WordPress response`,
-        pass: true,
-      };
-    } else {
-      return {
-        message: () => `expected ${JSON.stringify(received)} to be a valid WordPress response with status and data/error`,
-        pass: false,
-      };
-    }
-  },
-
-  toMatchMCPSchema(received: any) {
-    const pass = received &&
-      typeof received === 'object' &&
-      received.jsonrpc === '2.0' &&
-      (received.id !== undefined || received.method !== undefined);
-
-    if (pass) {
-      return {
-        message: () => `expected ${JSON.stringify(received)} not to match MCP schema`,
-        pass: true,
-      };
-    } else {
-      return {
-        message: () => `expected ${JSON.stringify(received)} to match MCP schema with jsonrpc: '2.0' and id or method`,
-        pass: false,
-      };
-    }
-  },
-});
-
 // Global test configuration
 beforeAll(async () => {
   // Set test environment variables
   process.env.NODE_ENV = 'test';
   process.env.MCP_WP_LOG_LEVEL = 'error'; // Reduce log noise during tests
-  
+
   // Mock console methods to reduce test output noise
   const originalConsole = global.console;
   global.console = {
@@ -145,7 +26,7 @@ beforeAll(async () => {
 beforeEach(() => {
   // Clear all mocks before each test
   jest.clearAllMocks();
-  
+
   // Reset environment variables
   delete process.env.MCP_WP_CLIENT_ID;
   delete process.env.MCP_WP_CLIENT_SECRET;

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -253,12 +253,6 @@ describe('Configuration Module', () => {
       expect(parseOAuthScopes(',read,write,', defaultScopes)).toEqual(['read', 'write']);
     });
 
-    it('should handle single scope correctly', async () => {
-      const { parseOAuthScopes } = await import('../../src/lib/config.js');
-      
-      const defaultScopes = ['read', 'write'];
-      expect(parseOAuthScopes('global', defaultScopes)).toEqual(['global']);
-    });
   });
 
 

--- a/tests/unit/init-ready-gate.test.ts
+++ b/tests/unit/init-ready-gate.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for the init-ready gate that prevents request handlers from
+ * running before transport detection completes.
+ *
+ * Regression test for: tools/list race condition where requests fired
+ * before sessionContext.transportType was set, causing them to be sent
+ * without a JSON-RPC envelope.
+ */
+
+import { jest } from '@jest/globals';
+import nock from 'nock';
+
+describe('init-ready gate', () => {
+  let createSessionContext: any;
+  let resolveInit: any;
+  let prepareRequest: any;
+  let waitForInit: any;
+  let createRequestHandler: any;
+  let HANDLER_CONFIGS: any;
+  let context: any;
+
+  beforeAll(async () => {
+    // Set env BEFORE modules are imported so CONFIG caches the right values
+    process.env.WP_API_URL = 'https://test-wp.example.com';
+    process.env.JWT_TOKEN = 'test-jwt-token-for-init-gate-tests';
+    process.env.NODE_ENV = 'test';
+
+    jest.resetModules();
+
+    const sessionMod = await import('../../src/lib/session-utils.js');
+    createSessionContext = sessionMod.createSessionContext;
+    resolveInit = sessionMod.resolveInit;
+    prepareRequest = sessionMod.prepareRequest;
+    waitForInit = sessionMod.waitForInit;
+
+    const factoryMod = await import('../../src/lib/request-handler-factory.js');
+    createRequestHandler = factoryMod.createRequestHandler;
+    HANDLER_CONFIGS = factoryMod.HANDLER_CONFIGS;
+  });
+
+  afterAll(() => {
+    delete process.env.JWT_TOKEN;
+    nock.cleanAll();
+  });
+
+  beforeEach(() => {
+    context = createSessionContext();
+    nock.cleanAll();
+    // Catch any real HTTP requests that escape the gate
+    nock('https://test-wp.example.com')
+      .post('/?rest_route=/wp/v2/wpmcp')
+      .reply(200, { tools: [] });
+  });
+
+  describe('waitForInit', () => {
+    it('blocks until resolveInit is called', async () => {
+      let resolved = false;
+      const waiting = waitForInit(context).then((result: any) => {
+        resolved = true;
+        return result;
+      });
+
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      resolveInit(context, false);
+      const result = await waiting;
+
+      expect(resolved).toBe(true);
+      expect(result).toEqual({ ready: true });
+    });
+
+    it('returns failed reason when init failed', async () => {
+      resolveInit(context, true);
+
+      const result = await waitForInit(context);
+      expect(result).toEqual({ ready: false, reason: 'failed' });
+    });
+
+    it('short-circuits after init already settled', async () => {
+      resolveInit(context, false);
+
+      // First call settles normally
+      expect(await waitForInit(context)).toEqual({ ready: true });
+      // Second call should return immediately (fast path)
+      expect(await waitForInit(context)).toEqual({ ready: true });
+    });
+
+    it('times out if init never resolves', async () => {
+      const result = await waitForInit(context, 50);
+      expect(result).toEqual({ ready: false, reason: 'timeout' });
+
+      // Resolve the dangling promise so Jest can exit cleanly
+      resolveInit(context, false);
+    });
+  });
+
+  describe('request handler waits for init', () => {
+    it('tools/list handler blocks until init completes', async () => {
+      const handler = createRequestHandler(HANDLER_CONFIGS.listTools, context);
+      let handlerResolved = false;
+
+      const handlerPromise = handler({ params: {} }).then((result: any) => {
+        handlerResolved = true;
+        return result;
+      });
+
+      // Handler should be blocked — flush microtasks without wall-clock delay
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(handlerResolved).toBe(false);
+
+      // Simulate successful init completing
+      context.transportType = 'jsonrpc';
+      resolveInit(context, false);
+
+      await handlerPromise;
+      expect(handlerResolved).toBe(true);
+    });
+
+    it('handler throws when init failed', async () => {
+      const handler = createRequestHandler(HANDLER_CONFIGS.listTools, context);
+
+      resolveInit(context, true);
+
+      await expect(handler({ params: {} })).rejects.toThrow(
+        'Cannot process tools/list: WordPress connection failed during initialization'
+      );
+    });
+
+    it('handler times out with error when init never completes', async () => {
+      const handler = createRequestHandler(HANDLER_CONFIGS.listTools, context);
+
+      const timeoutPromise = handler({ params: {} });
+
+      // Simulate timeout by resolving init as failed after a short delay
+      setTimeout(() => resolveInit(context, true), 50);
+
+      await expect(timeoutPromise).rejects.toThrow(
+        'WordPress connection failed during initialization'
+      );
+    });
+  });
+
+  describe('race condition regression', () => {
+    it('tools/list uses correct transport even when fired immediately after init', async () => {
+      nock.cleanAll();
+      let capturedBody: any = null;
+      nock('https://test-wp.example.com')
+        .post('/?rest_route=/wp/v2/wpmcp', (body: any) => {
+          capturedBody = body;
+          return true;
+        })
+        .reply(200, { tools: [] });
+
+      const handler = createRequestHandler(HANDLER_CONFIGS.listTools, context);
+
+      // Fire tools/list immediately (simulates MCP SDK behavior on startup)
+      const handlerPromise = handler({ id: 1, params: {} });
+
+      // Simulate init completing with jsonrpc transport
+      context.transportType = 'jsonrpc';
+      context.sessionId = 'test-session';
+      resolveInit(context, false);
+
+      await handlerPromise;
+
+      // The request body must contain a JSON-RPC envelope
+      expect(capturedBody).toHaveProperty('jsonrpc', '2.0');
+      expect(capturedBody).toHaveProperty('method', 'tools/list');
+    });
+
+    it('prepareRequest falls through to simple format when transportType is null', () => {
+      // Documents the original bug: without the gate, transportType is null
+      // and requests get sent without a JSON-RPC envelope
+      const wpParams = { method: 'tools/list' };
+      const mcpRequest = { id: 1 };
+
+      // Before init: transportType is null -> no jsonrpc envelope
+      const result = prepareRequest(wpParams, mcpRequest, context);
+      expect(result).not.toHaveProperty('jsonrpc');
+      expect(result).toEqual({ method: 'tools/list' });
+
+      // After init: transportType is 'jsonrpc' -> full envelope
+      context.transportType = 'jsonrpc';
+      const resultAfter = prepareRequest(wpParams, mcpRequest, context);
+      expect(resultAfter).toHaveProperty('jsonrpc', '2.0');
+      expect(resultAfter).toHaveProperty('method', 'tools/list');
+    });
+
+    it('multiple concurrent handlers all unblock when init completes', async () => {
+      nock.cleanAll();
+      nock('https://test-wp.example.com')
+        .post('/?rest_route=/wp/v2/wpmcp')
+        .times(3)
+        .reply(200, { tools: [{ name: 'test-tool' }] });
+
+      const toolsHandler = createRequestHandler(HANDLER_CONFIGS.listTools, context);
+      const resourcesHandler = createRequestHandler(HANDLER_CONFIGS.listResources, context);
+      const promptsHandler = createRequestHandler(HANDLER_CONFIGS.listPrompts, context);
+
+      // Fire three handlers concurrently before init
+      const p1 = toolsHandler({ id: 1, params: {} });
+      const p2 = resourcesHandler({ id: 2, params: {} });
+      const p3 = promptsHandler({ id: 3, params: {} });
+
+      // Complete init
+      context.transportType = 'jsonrpc';
+      resolveInit(context, false);
+
+      // All three should resolve successfully with response data
+      const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+      expect(r1).toHaveProperty('tools');
+      expect(r2).toHaveProperty('tools');
+      expect(r3).toHaveProperty('tools');
+    });
+  });
+});

--- a/tests/unit/mcp-oauth-utils.test.ts
+++ b/tests/unit/mcp-oauth-utils.test.ts
@@ -3,7 +3,6 @@
  */
 
 import { jest } from '@jest/globals';
-import crypto from 'crypto';
 
 describe('MCP OAuth Utils', () => {
   describe('generatePKCE', () => {
@@ -39,18 +38,16 @@ describe('MCP OAuth Utils', () => {
       expect(pkce1.codeChallenge).not.toBe(pkce2.codeChallenge);
     });
 
-    it('should generate consistent challenge from verifier', async () => {
+    it('should produce a base64url-encoded SHA-256 challenge (no padding)', async () => {
       const { generatePKCE } = await import('../../src/lib/mcp-oauth-utils.js');
-      
-      const pkce = generatePKCE();
-      
-      // Manually calculate expected challenge
-      const expectedChallenge = crypto
-        .createHash('sha256')
-        .update(pkce.codeVerifier)
-        .digest('base64url');
 
-      expect(pkce.codeChallenge).toBe(expectedChallenge);
+      const pkce = generatePKCE();
+
+      // S256 challenges are 43 chars of base64url (256 bits / 6 bits per char, no padding)
+      expect(pkce.codeChallenge).toHaveLength(43);
+      expect(pkce.codeChallenge).toMatch(/^[A-Za-z0-9_-]+$/);
+      // Must not contain base64 padding characters
+      expect(pkce.codeChallenge).not.toContain('=');
     });
   });
 

--- a/tests/unit/persistent-auth-config.test.ts
+++ b/tests/unit/persistent-auth-config.test.ts
@@ -43,7 +43,7 @@ describe('Persistent Auth Config Module', () => {
       await ensureConfigDir();
       const configDir = getConfigDir();
       
-      expect(configDir).toContain('wordpress-remote-0.2.1');
+      expect(configDir).toMatch(/wordpress-remote-\d+\.\d+\.\d+/);
       expect(fsSync.existsSync(configDir)).toBe(true);
       
       // Check permissions (on Unix systems)
@@ -60,16 +60,19 @@ describe('Persistent Auth Config Module', () => {
       const configDir = getConfigDir();
       
       // In test environment, we may use different directory paths
-      expect(configDir).toContain('wordpress-remote-0.2.1');
+      expect(configDir).toMatch(/wordpress-remote-\d+\.\d+\.\d+/);
     });
 
     it('should handle config directory creation errors gracefully', async () => {
-      // Create a file where the directory should be to cause an error
-      const conflictPath = path.join(tempDir, 'wordpress-remote-0.2.1');
+      // Create a file where the versioned directory should be to cause an error.
+      // getConfigDir() returns path.join(tempDir, 'wordpress-remote-<VERSION>'),
+      // so we must use the actual version string to trigger the conflict.
+      const { getConfigDir, ensureConfigDir } = await import('../../src/lib/persistent-auth-config.js');
+      const conflictPath = getConfigDir();
+      // Ensure parent exists, then place a regular file where mkdir expects a directory
+      await fs.mkdir(path.dirname(conflictPath), { recursive: true });
       await fs.writeFile(conflictPath, 'conflict');
 
-      const { ensureConfigDir } = await import('../../src/lib/persistent-auth-config.js');
-      
       await expect(ensureConfigDir()).rejects.toThrow();
     });
   });

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -16,7 +16,7 @@ describe('Utils Module', () => {
   beforeEach(() => {
     jest.resetModules();
     tempDir = tmp.dirSync({ unsafeCleanup: true }).name;
-    
+
     // Mock stderr to capture log output
     originalStderr = process.stderr.write;
     process.stderr.write = jest.fn(() => true);
@@ -28,48 +28,50 @@ describe('Utils Module', () => {
     }
     // Restore stderr
     process.stderr.write = originalStderr;
-    
+
     // Cleanup temp directory
     if (fs.existsSync(tempDir)) {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });
 
-  describe('LogLevel enum', () => {
-    it('should have correct log level values', async () => {
-      const { LogLevel } = await import('../../src/lib/utils.js');
-      
-      expect(LogLevel.ERROR).toBe(0);
-      expect(LogLevel.WARN).toBe(1);
-      expect(LogLevel.INFO).toBe(2);
-      expect(LogLevel.DEBUG).toBe(3);
-    });
-  });
-
-  describe('Version constant', () => {
-    it('should export version constant', async () => {
-      const { MCP_WORDPRESS_REMOTE_VERSION } = await import('../../src/lib/utils.js');
-      
-      expect(MCP_WORDPRESS_REMOTE_VERSION).toBe('0.2.19');
-    });
-  });
-
   describe('Log function', () => {
-    it('should log messages with correct format', async () => {
+    // log() only writes to stderr when LOG_TO_STDERR=true.
+    // These tests set that env var before importing the module.
+
+    it('should log messages to stderr with correct format when LOG_TO_STDERR is true', async () => {
+      restoreEnv = mockEnv({
+        LOG_TO_STDERR: 'true',
+      });
+
       const { log, LogLevel } = await import('../../src/lib/utils.js');
-      
+
       log('Test message', LogLevel.INFO, 'TEST');
-      
+
       expect(process.stderr.write).toHaveBeenCalledWith(
         expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \[INFO\] \[TEST\] Test message\n$/)
       );
     });
 
-    it('should log with default level and category', async () => {
+    it('should not write to stderr when LOG_TO_STDERR is not set', async () => {
+      restoreEnv = mockEnv({});
+
+      const { log, LogLevel } = await import('../../src/lib/utils.js');
+
+      log('Test message', LogLevel.INFO, 'TEST');
+
+      expect(process.stderr.write).not.toHaveBeenCalled();
+    });
+
+    it('should log with default level INFO and category GENERAL', async () => {
+      restoreEnv = mockEnv({
+        LOG_TO_STDERR: 'true',
+      });
+
       const { log } = await import('../../src/lib/utils.js');
-      
+
       log('Default test');
-      
+
       expect(process.stderr.write).toHaveBeenCalledWith(
         expect.stringMatching(/\[INFO\] \[GENERAL\] Default test\n$/)
       );
@@ -77,14 +79,15 @@ describe('Utils Module', () => {
 
     it('should include additional arguments in log output', async () => {
       restoreEnv = mockEnv({
+        LOG_TO_STDERR: 'true',
         LOG_LEVEL: '3', // DEBUG level to see the message
       });
-      
+
       const { log, LogLevel } = await import('../../src/lib/utils.js');
-      
+
       const testObj = { key: 'value', number: 42 };
       log('Test with args', LogLevel.DEBUG, 'TEST', testObj, 'string arg');
-      
+
       expect(process.stderr.write).toHaveBeenCalledWith(
         expect.stringMatching(/Test with args\n.*"key":\s*"value".*string arg/s)
       );
@@ -92,62 +95,65 @@ describe('Utils Module', () => {
 
     it('should respect log level filtering', async () => {
       restoreEnv = mockEnv({
+        LOG_TO_STDERR: 'true',
         LOG_LEVEL: '1', // WARN level
       });
-      
+
       const { log, LogLevel } = await import('../../src/lib/utils.js');
-      
+
       // ERROR and WARN should be logged
       log('Error message', LogLevel.ERROR, 'TEST');
       log('Warn message', LogLevel.WARN, 'TEST');
-      
+
       // INFO and DEBUG should be filtered out
       log('Info message', LogLevel.INFO, 'TEST');
       log('Debug message', LogLevel.DEBUG, 'TEST');
-      
+
       expect(process.stderr.write).toHaveBeenCalledTimes(2);
     });
 
     it('should use DEBUG level in development environment', async () => {
       restoreEnv = mockEnv({
+        LOG_TO_STDERR: 'true',
         NODE_ENV: 'development',
       });
-      
+
       const { log, LogLevel } = await import('../../src/lib/utils.js');
-      
+
       // In development, DEBUG messages should be logged
       log('Debug message', LogLevel.DEBUG, 'TEST');
-      
+
       expect(process.stderr.write).toHaveBeenCalled();
     });
 
     it('should use INFO level by default in non-development', async () => {
       restoreEnv = mockEnv({
+        LOG_TO_STDERR: 'true',
         NODE_ENV: 'production',
       });
-      
+
       const { log, LogLevel } = await import('../../src/lib/utils.js');
-      
+
       // DEBUG should be filtered out
       log('Debug message', LogLevel.DEBUG, 'TEST');
-      
+
       // INFO should be logged
       log('Info message', LogLevel.INFO, 'TEST');
-      
+
       expect(process.stderr.write).toHaveBeenCalledTimes(1);
     });
 
     it('should log to file when LOG_FILE is configured', async () => {
       const logFile = path.join(tempDir, 'test.log');
-      
+
       restoreEnv = mockEnv({
         LOG_FILE: logFile,
       });
-      
+
       const { log, LogLevel } = await import('../../src/lib/utils.js');
-      
+
       log('File log test', LogLevel.INFO, 'TEST');
-      
+
       expect(fs.existsSync(logFile)).toBe(true);
       const logContent = fs.readFileSync(logFile, 'utf-8');
       expect(logContent).toContain('File log test');
@@ -156,115 +162,96 @@ describe('Utils Module', () => {
     it('should create log directory if it does not exist', async () => {
       const logDir = path.join(tempDir, 'logs');
       const logFile = path.join(logDir, 'test.log');
-      
+
       restoreEnv = mockEnv({
         LOG_FILE: logFile,
       });
-      
+
       // Import should create the directory
       await import('../../src/lib/utils.js');
-      
+
       expect(fs.existsSync(logDir)).toBe(true);
     });
   });
 
   describe('Logger convenience functions', () => {
-    it('should provide error logging function', async () => {
-      const { logger } = await import('../../src/lib/utils.js');
-      
-      logger.error('Error message', 'CUSTOM', { error: 'data' });
-      
-      expect(process.stderr.write).toHaveBeenCalledWith(
-        expect.stringMatching(/\[ERROR\] \[CUSTOM\] Error message\n.*"error":\s*"data"/s)
-      );
-    });
+    // Consolidated: each convenience function routes to log() with correct level and category.
+    // We verify them using LOG_TO_STDERR + LOG_LEVEL=3 to capture all messages.
 
-    it('should provide warn logging function', async () => {
-      const { logger } = await import('../../src/lib/utils.js');
-      
-      logger.warn('Warning message');
-      
-      expect(process.stderr.write).toHaveBeenCalledWith(
-        expect.stringMatching(/\[WARN\] \[WARN\] Warning message\n$/)
-      );
-    });
-
-    it('should provide info logging function', async () => {
-      const { logger } = await import('../../src/lib/utils.js');
-      
-      logger.info('Info message');
-      
-      expect(process.stderr.write).toHaveBeenCalledWith(
-        expect.stringMatching(/\[INFO\] \[INFO\] Info message\n$/)
-      );
-    });
-
-    it('should provide debug logging function', async () => {
+    it.each([
+      ['error', 'ERROR', 'CUSTOM', 'Error message'],
+      ['warn', 'WARN', 'WARN', 'Warning message'],
+      ['info', 'INFO', 'INFO', 'Info message'],
+    ] as const)('logger.%s logs with [%s] level', async (method, level, category, message) => {
       restoreEnv = mockEnv({
+        LOG_TO_STDERR: 'true',
+        LOG_LEVEL: '3',
+      });
+
+      const { logger } = await import('../../src/lib/utils.js');
+
+      if (method === 'error') {
+        logger.error(message, category);
+      } else if (method === 'warn') {
+        logger.warn(message);
+      } else {
+        logger.info(message);
+      }
+
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringMatching(new RegExp(`\\[${level}\\] \\[${category}\\] ${message}\\n$`))
+      );
+    });
+
+    it('logger.debug logs at DEBUG level', async () => {
+      restoreEnv = mockEnv({
+        LOG_TO_STDERR: 'true',
         LOG_LEVEL: '3', // DEBUG level
       });
-      
+
       const { logger } = await import('../../src/lib/utils.js');
-      
+
       logger.debug('Debug message');
-      
+
       expect(process.stderr.write).toHaveBeenCalledWith(
         expect.stringMatching(/\[DEBUG\] \[DEBUG\] Debug message\n$/)
       );
     });
 
     describe('Specialized category loggers', () => {
-      beforeEach(() => {
+      // Consolidated: auth, oauth, api, config all follow the same pattern.
+      // One parameterized test covers them all.
+
+      it.each([
+        ['auth', 'AUTH'],
+        ['oauth', 'OAUTH'],
+        ['api', 'API'],
+        ['config', 'CONFIG'],
+      ] as const)('logger.%s logs with [INFO] [%s] category', async (method, category) => {
         restoreEnv = mockEnv({
-          LOG_LEVEL: '3', // DEBUG level to see all messages
+          LOG_TO_STDERR: 'true',
+          LOG_LEVEL: '3',
         });
-      });
 
-      it('should provide auth logger', async () => {
         const { logger } = await import('../../src/lib/utils.js');
-        
-        logger.auth('Auth message');
-        
-        expect(process.stderr.write).toHaveBeenCalledWith(
-          expect.stringMatching(/\[INFO\] \[AUTH\] Auth message\n$/)
-        );
-      });
 
-      it('should provide oauth logger', async () => {
-        const { logger } = await import('../../src/lib/utils.js');
-        
-        logger.oauth('OAuth message');
-        
-        expect(process.stderr.write).toHaveBeenCalledWith(
-          expect.stringMatching(/\[INFO\] \[OAUTH\] OAuth message\n$/)
-        );
-      });
+        (logger as any)[method](`${category} test message`);
 
-      it('should provide api logger', async () => {
-        const { logger } = await import('../../src/lib/utils.js');
-        
-        logger.api('API message');
-        
         expect(process.stderr.write).toHaveBeenCalledWith(
-          expect.stringMatching(/\[INFO\] \[API\] API message\n$/)
-        );
-      });
-
-      it('should provide config logger', async () => {
-        const { logger } = await import('../../src/lib/utils.js');
-        
-        logger.config('Config message');
-        
-        expect(process.stderr.write).toHaveBeenCalledWith(
-          expect.stringMatching(/\[INFO\] \[CONFIG\] Config message\n$/)
+          expect.stringMatching(new RegExp(`\\[INFO\\] \\[${category}\\] ${category} test message\\n$`))
         );
       });
 
       it('should allow custom log levels in specialized loggers', async () => {
+        restoreEnv = mockEnv({
+          LOG_TO_STDERR: 'true',
+          LOG_LEVEL: '3',
+        });
+
         const { logger, LogLevel } = await import('../../src/lib/utils.js');
-        
+
         logger.auth('Error auth message', LogLevel.ERROR);
-        
+
         expect(process.stderr.write).toHaveBeenCalledWith(
           expect.stringMatching(/\[ERROR\] \[AUTH\] Error auth message\n$/)
         );
@@ -275,32 +262,32 @@ describe('Utils Module', () => {
   describe('Signal handlers', () => {
     it('should set up signal handlers for cleanup', async () => {
       const { setupSignalHandlers } = await import('../../src/lib/utils.js');
-      
+
       const mockCleanup = jest.fn() as jest.MockedFunction<() => Promise<void>>;
       mockCleanup.mockResolvedValue(void 0);
       const originalOn = process.on;
       const mockOn = jest.fn();
       process.on = mockOn as any;
-      
+
       setupSignalHandlers(mockCleanup);
-      
+
       expect(mockOn).toHaveBeenCalledWith('SIGINT', expect.any(Function));
       expect(mockOn).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
       expect(mockOn).toHaveBeenCalledWith('SIGHUP', expect.any(Function));
-      
+
       // Restore process.on
       process.on = originalOn;
     });
 
     it('should call cleanup function when signal is received', async () => {
       const { setupSignalHandlers } = await import('../../src/lib/utils.js');
-      
+
       const mockCleanup = jest.fn() as jest.MockedFunction<() => Promise<void>>;
       mockCleanup.mockResolvedValue(void 0);
       const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
         throw new Error('process.exit');
       });
-      
+
       let signalHandler: Function | undefined;
       const mockOn = jest.fn().mockImplementation((signal: any, handler: any) => {
         if (signal === 'SIGINT') {
@@ -309,16 +296,16 @@ describe('Utils Module', () => {
       });
       const originalOn = process.on;
       process.on = mockOn as any;
-      
+
       setupSignalHandlers(mockCleanup);
-      
+
       // Simulate SIGINT signal - should throw because of mocked exit
       if (signalHandler) {
         await expect(signalHandler()).rejects.toThrow('process.exit');
       }
-      
+
       expect(mockCleanup).toHaveBeenCalled();
-      
+
       // Restore
       process.on = originalOn;
       mockExit.mockRestore();
@@ -326,24 +313,24 @@ describe('Utils Module', () => {
   });
 
   describe('Server URL hash', () => {
-    it('should generate consistent SHA-256 hash for server URL', async () => {
+    it('should generate consistent 8-char hex hash from SHA-256', async () => {
       const { getServerUrlHash } = await import('../../src/lib/utils.js');
-      
+
       const serverUrl = 'https://example.com';
       const hash1 = getServerUrlHash(serverUrl);
       const hash2 = getServerUrlHash(serverUrl);
-      
+
       expect(hash1).toBe(hash2);
-      expect(hash1).toHaveLength(8); // Substring of SHA-256 hex
+      expect(hash1).toHaveLength(8);
       expect(hash1).toMatch(/^[a-f0-9]+$/);
     });
 
     it('should generate different hashes for different URLs', async () => {
       const { getServerUrlHash } = await import('../../src/lib/utils.js');
-      
+
       const hash1 = getServerUrlHash('https://example.com');
       const hash2 = getServerUrlHash('https://different.com');
-      
+
       expect(hash1).not.toBe(hash2);
     });
   });
@@ -351,108 +338,70 @@ describe('Utils Module', () => {
   describe('Coordinator server', () => {
     it('should create HTTP server on specified port', async () => {
       const { createCoordinatorServer } = await import('../../src/lib/utils.js');
-      
+
       const { server, port } = createCoordinatorServer(0); // Use port 0 for random assignment
-      
+
       expect(server).toBeDefined();
       expect(port).toBe(0);
-      
+
       // Cleanup
       server.close();
     });
 
     it('should log when server starts listening', async () => {
+      restoreEnv = mockEnv({
+        LOG_TO_STDERR: 'true',
+      });
+
       const { createCoordinatorServer } = await import('../../src/lib/utils.js');
-      
+
       const { server } = createCoordinatorServer(0);
-      
-      // Wait a bit for the server to start
-      await new Promise(resolve => setTimeout(resolve, 10));
-      
+
+      // Wait for the server to start
+      await new Promise(resolve => setTimeout(resolve, 50));
+
       expect(process.stderr.write).toHaveBeenCalledWith(
         expect.stringMatching(/Coordinator server listening on port/)
       );
-      
+
       // Cleanup
       server.close();
     });
   });
 
-  describe('Remote server connection', () => {
-    it('should create SSE transport with correct URL and headers', async () => {
-      const { connectToRemoteServer } = await import('../../src/lib/utils.js');
-      
-      const serverUrl = 'https://example.com/sse';
-      const headers = { 'Authorization': 'Bearer token' };
-      
-      const transport = await connectToRemoteServer(serverUrl, headers);
-      
-      expect(transport).toBeDefined();
-      expect(transport.onmessage).toBeDefined();
-      expect(transport.onerror).toBeDefined();
-      expect(transport.onclose).toBeDefined();
-    });
-
-    it('should set up message handlers on transport', async () => {
-      const { connectToRemoteServer } = await import('../../src/lib/utils.js');
-      
-      const transport = await connectToRemoteServer('https://example.com/sse', {});
-      
-      // Test message handler
-      const testMessage = { type: 'test' } as any;
-      if (transport.onmessage) {
-        transport.onmessage(testMessage);
-      }
-      
-      // Test error handler
-      const testError = new Error('Test error');
-      if (transport.onerror) {
-        transport.onerror(testError);
-      }
-      
-      // Test close handler
-      if (transport.onclose) {
-        transport.onclose();
-      }
-      
-      // Should not throw errors
-      expect(true).toBe(true);
-    });
-  });
-
   describe('MCP Proxy', () => {
-    it('should handle incoming messages from client', async () => {
+    it('should forward request to WordPress and return JSON-RPC response', async () => {
       const { mcpProxy } = await import('../../src/lib/utils.js');
-      
+
       const mockTransport = {
         onmessage: null as any,
         send: jest.fn(),
       };
-      
+
       const mockWpRequest = jest.fn() as jest.MockedFunction<(params: any) => Promise<any>>;
       mockWpRequest.mockResolvedValue({ status: 'success' });
-      
+
       mcpProxy({
         transportToClient: mockTransport as any,
         wpRequest: mockWpRequest as any,
       });
-      
+
       expect(mockTransport.onmessage).toBeDefined();
-      
+
       // Simulate incoming message
       const testMessage = {
         id: 'test-id',
         method: 'test-method',
         params: { test: 'param' },
       };
-      
+
       await mockTransport.onmessage(testMessage);
-      
+
       expect(mockWpRequest).toHaveBeenCalledWith({
         method: 'test-method',
         test: 'param',
       });
-      
+
       expect(mockTransport.send).toHaveBeenCalledWith({
         jsonrpc: '2.0',
         id: 'test-id',
@@ -460,31 +409,28 @@ describe('Utils Module', () => {
       });
     });
 
-    it('should handle errors in message processing', async () => {
+    it('should send JSON-RPC error when request fails with Error', async () => {
       const { mcpProxy } = await import('../../src/lib/utils.js');
-      
+
       const mockTransport = {
         onmessage: null as any,
         send: jest.fn(),
       };
-      
+
       const mockWpRequest = jest.fn() as jest.MockedFunction<(params: any) => Promise<any>>;
       mockWpRequest.mockRejectedValue(new Error('Request failed'));
-      
+
       mcpProxy({
         transportToClient: mockTransport as any,
         wpRequest: mockWpRequest as any,
       });
-      
-      // Simulate incoming message
-      const testMessage = {
+
+      await mockTransport.onmessage({
         id: 'test-id',
         method: 'test-method',
         params: {},
-      };
-      
-      await mockTransport.onmessage(testMessage);
-      
+      });
+
       expect(mockTransport.send).toHaveBeenCalledWith({
         jsonrpc: '2.0',
         id: 'test-id',
@@ -495,31 +441,28 @@ describe('Utils Module', () => {
       });
     });
 
-    it('should handle non-Error exceptions', async () => {
+    it('should coerce non-Error exceptions to string in error response', async () => {
       const { mcpProxy } = await import('../../src/lib/utils.js');
-      
+
       const mockTransport = {
         onmessage: null as any,
         send: jest.fn(),
       };
-      
+
       const mockWpRequest = jest.fn() as jest.MockedFunction<(params: any) => Promise<any>>;
       mockWpRequest.mockRejectedValue('String error');
-      
+
       mcpProxy({
         transportToClient: mockTransport as any,
         wpRequest: mockWpRequest as any,
       });
-      
-      // Simulate incoming message
-      const testMessage = {
+
+      await mockTransport.onmessage({
         id: 'test-id',
         method: 'test-method',
         params: {},
-      };
-      
-      await mockTransport.onmessage(testMessage);
-      
+      });
+
       expect(mockTransport.send).toHaveBeenCalledWith({
         jsonrpc: '2.0',
         id: 'test-id',
@@ -532,27 +475,25 @@ describe('Utils Module', () => {
 
     it('should ignore messages without method', async () => {
       const { mcpProxy } = await import('../../src/lib/utils.js');
-      
+
       const mockTransport = {
         onmessage: null as any,
         send: jest.fn(),
       };
-      
+
       const mockWpRequest = jest.fn();
-      
+
       mcpProxy({
         transportToClient: mockTransport as any,
         wpRequest: mockWpRequest as any,
       });
-      
+
       // Simulate incoming message without method
-      const testMessage = {
+      await mockTransport.onmessage({
         id: 'test-id',
         params: {},
-      };
-      
-      await mockTransport.onmessage(testMessage);
-      
+      });
+
       expect(mockWpRequest).not.toHaveBeenCalled();
       expect(mockTransport.send).not.toHaveBeenCalled();
     });

--- a/tests/unit/wordpress-api.test.ts
+++ b/tests/unit/wordpress-api.test.ts
@@ -1,5 +1,8 @@
 /**
  * Unit tests for wordpress-api module
+ *
+ * Tests the wpRequest function: URL construction, authentication dispatch,
+ * request formatting, and error handling.
  */
 
 import { jest } from '@jest/globals';
@@ -26,6 +29,9 @@ jest.unstable_mockModule('../../src/lib/coordination.js', () => ({
   }),
 }));
 
+// The WordPress MCP endpoint used by the source code
+const WP_MCP_ENDPOINT = '/?rest_route=/wp/v2/wpmcp';
+
 describe('WordPress API Module', () => {
   let restoreEnv: () => void;
 
@@ -49,7 +55,7 @@ describe('WordPress API Module', () => {
         });
 
         const { wpRequest } = await import('../../src/lib/wordpress-api.js');
-        
+
         await expect(wpRequest({ method: 'initialize' })).rejects.toThrow(
           'Configuration validation failed'
         );
@@ -61,13 +67,12 @@ describe('WordPress API Module', () => {
           JWT_TOKEN: 'test-jwt-token',
         });
 
-        // Mock the API response
         nock('https://test-site.com')
-          .post('/?rest_route=/wp/v2/mcp/v1')
+          .post(WP_MCP_ENDPOINT)
           .reply(200, { status: 'success', data: 'test' });
 
         const { wpRequest } = await import('../../src/lib/wordpress-api.js');
-        
+
         const response = await wpRequest({ method: 'initialize' });
         expect(response).toEqual({ status: 'success', data: 'test' });
       });
@@ -76,12 +81,12 @@ describe('WordPress API Module', () => {
     describe('URL construction', () => {
       it('should use REST route format for standard WordPress sites', async () => {
         restoreEnv = mockEnv({
-          WP_API_URL: 'https://example.com',
+          WP_API_URL: 'https://my-wp-site.com',
           JWT_TOKEN: 'test-jwt-token',
         });
 
-        nock('https://example.com')
-          .post('/?rest_route=/wp/v2/mcp/v1')
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT)
           .reply(200, { status: 'success' });
 
         const { wpRequest } = await import('../../src/lib/wordpress-api.js');
@@ -90,15 +95,13 @@ describe('WordPress API Module', () => {
         expect(nock.isDone()).toBe(true);
       });
 
-
-
       it('should use exact URL when custom path is provided', async () => {
         restoreEnv = mockEnv({
-          WP_API_URL: 'https://example.com/custom/path',
+          WP_API_URL: 'https://my-wp-site.com/custom/path',
           JWT_TOKEN: 'test-jwt-token',
         });
 
-        nock('https://example.com')
+        nock('https://my-wp-site.com')
           .post('/custom/path')
           .reply(200, { status: 'success' });
 
@@ -110,12 +113,12 @@ describe('WordPress API Module', () => {
 
       it('should remove trailing slashes from URL', async () => {
         restoreEnv = mockEnv({
-          WP_API_URL: 'https://example.com///',
+          WP_API_URL: 'https://my-wp-site.com///',
           JWT_TOKEN: 'test-jwt-token',
         });
 
-        nock('https://example.com')
-          .post('/?rest_route=/wp/v2/mcp/v1')
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT)
           .reply(200, { status: 'success' });
 
         const { wpRequest } = await import('../../src/lib/wordpress-api.js');
@@ -129,12 +132,12 @@ describe('WordPress API Module', () => {
       describe('JWT Token authentication', () => {
         it('should use JWT token when available', async () => {
           restoreEnv = mockEnv({
-            WP_API_URL: 'https://example.com',
+            WP_API_URL: 'https://my-wp-site.com',
             JWT_TOKEN: 'test-jwt-token-12345',
           });
 
-          nock('https://example.com')
-            .post('/?rest_route=/wp/v2/mcp/v1')
+          nock('https://my-wp-site.com')
+            .post(WP_MCP_ENDPOINT)
             .matchHeader('authorization', 'Bearer test-jwt-token-12345')
             .reply(200, { status: 'success' });
 
@@ -143,38 +146,20 @@ describe('WordPress API Module', () => {
 
           expect(nock.isDone()).toBe(true);
         });
-
-        it('should log JWT token length for debugging', async () => {
-          restoreEnv = mockEnv({
-            WP_API_URL: 'https://example.com',
-            JWT_TOKEN: 'test-jwt-token',
-          });
-
-          nock('https://example.com')
-            .post('/?rest_route=/wp/v2/mcp/v1')
-            .reply(200, { status: 'success' });
-
-          const logSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-          const { wpRequest } = await import('../../src/lib/wordpress-api.js');
-          await wpRequest({ method: 'initialize' });
-
-          logSpy.mockRestore();
-        });
       });
 
       describe('Basic Auth authentication', () => {
         it('should use WordPress Basic Auth when JWT is not available', async () => {
           restoreEnv = mockEnv({
-            WP_API_URL: 'https://example.com',
+            WP_API_URL: 'https://my-wp-site.com',
             WP_API_USERNAME: 'testuser',
             WP_API_PASSWORD: 'testpass',
           });
 
           const expectedAuth = Buffer.from('testuser:testpass').toString('base64');
-          
-          nock('https://example.com')
-            .post('/?rest_route=/wp/v2/mcp/v1')
+
+          nock('https://my-wp-site.com')
+            .post(WP_MCP_ENDPOINT)
             .matchHeader('authorization', `Basic ${expectedAuth}`)
             .reply(200, { status: 'success' });
 
@@ -186,22 +171,24 @@ describe('WordPress API Module', () => {
 
         it('should use WooCommerce credentials for WooCommerce report tools', async () => {
           restoreEnv = mockEnv({
-            WP_API_URL: 'https://example.com',
+            WP_API_URL: 'https://my-wp-site.com',
+            WP_API_USERNAME: 'wp-user',
+            WP_API_PASSWORD: 'wp-pass',
             WOO_CUSTOMER_KEY: 'woo_key',
             WOO_CUSTOMER_SECRET: 'woo_secret',
           });
 
           const expectedAuth = Buffer.from('woo_key:woo_secret').toString('base64');
-          
-          nock('https://example.com')
-            .post('/?rest_route=/wp/v2/mcp/v1')
+
+          nock('https://my-wp-site.com')
+            .post(WP_MCP_ENDPOINT)
             .matchHeader('authorization', `Basic ${expectedAuth}`)
             .reply(200, { status: 'success' });
 
           const { wpRequest } = await import('../../src/lib/wordpress-api.js');
-          await wpRequest({ 
+          await wpRequest({
             method: 'tools/call',
-            args: { tool: 'wc_reports_sales' }
+            params: { name: 'wc_reports_sales' },
           });
 
           expect(nock.isDone()).toBe(true);
@@ -209,15 +196,17 @@ describe('WordPress API Module', () => {
 
         it('should throw AuthError when WooCommerce credentials are missing for WooCommerce tools', async () => {
           restoreEnv = mockEnv({
-            WP_API_URL: 'https://example.com',
+            WP_API_URL: 'https://my-wp-site.com',
+            WP_API_USERNAME: 'testuser',
+            WP_API_PASSWORD: 'testpass',
             // Missing WOO_CUSTOMER_KEY and WOO_CUSTOMER_SECRET
           });
 
           const { wpRequest } = await import('../../src/lib/wordpress-api.js');
-          
-          await expect(wpRequest({ 
+
+          await expect(wpRequest({
             method: 'tools/call',
-            args: { tool: 'wc_reports_sales' }
+            params: { name: 'wc_reports_sales' },
           })).rejects.toThrow('Missing WooCommerce credentials');
         });
       });
@@ -225,19 +214,14 @@ describe('WordPress API Module', () => {
       describe('OAuth authentication', () => {
         it('should attempt OAuth when enabled and no JWT token', async () => {
           restoreEnv = mockEnv({
-            WP_API_URL: 'https://example.com',
+            WP_API_URL: 'https://my-wp-site.com',
             OAUTH_ENABLED: 'true',
             WP_OAUTH_CLIENT_ID: 'test-client-id',
           });
 
-          // Mock OAuth to return no tokens (will fallback to Basic Auth)
-          nock('https://example.com')
-            .post('/?rest_route=/wp/v2/mcp/v1')
-            .reply(200, { status: 'success' });
-
           const { wpRequest } = await import('../../src/lib/wordpress-api.js');
-          
-          // This should attempt OAuth but fallback gracefully
+
+          // OAuth mock returns null tokens, no Basic Auth fallback either
           await expect(wpRequest({ method: 'initialize' })).rejects.toThrow(
             'No authentication method available'
           );
@@ -245,7 +229,7 @@ describe('WordPress API Module', () => {
 
         it('should fallback to Basic Auth when OAuth fails', async () => {
           restoreEnv = mockEnv({
-            WP_API_URL: 'https://example.com',
+            WP_API_URL: 'https://my-wp-site.com',
             OAUTH_ENABLED: 'true',
             WP_OAUTH_CLIENT_ID: 'test-client-id',
             WP_API_USERNAME: 'fallback-user',
@@ -253,9 +237,9 @@ describe('WordPress API Module', () => {
           });
 
           const expectedAuth = Buffer.from('fallback-user:fallback-pass').toString('base64');
-          
-          nock('https://example.com')
-            .post('/?rest_route=/wp/v2/mcp/v1')
+
+          nock('https://my-wp-site.com')
+            .post(WP_MCP_ENDPOINT)
             .matchHeader('authorization', `Basic ${expectedAuth}`)
             .reply(200, { status: 'success' });
 
@@ -269,14 +253,14 @@ describe('WordPress API Module', () => {
       describe('No authentication', () => {
         it('should throw AuthError when no authentication method is configured', async () => {
           restoreEnv = mockEnv({
-            WP_API_URL: 'https://example.com',
+            WP_API_URL: 'https://my-wp-site.com',
             // No authentication methods configured
           });
 
           const { wpRequest } = await import('../../src/lib/wordpress-api.js');
-          
+
           await expect(wpRequest({ method: 'initialize' })).rejects.toThrow(
-            'No authentication method available'
+            'No authentication method'
           );
         });
       });
@@ -285,12 +269,12 @@ describe('WordPress API Module', () => {
     describe('Request handling', () => {
       it('should send POST request with correct headers', async () => {
         restoreEnv = mockEnv({
-          WP_API_URL: 'https://example.com',
+          WP_API_URL: 'https://my-wp-site.com',
           JWT_TOKEN: 'test-token',
         });
 
-        nock('https://example.com')
-          .post('/?rest_route=/wp/v2/mcp/v1')
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT)
           .matchHeader('authorization', 'Bearer test-token')
           .matchHeader('content-type', 'application/json')
           .reply(200, { status: 'success' });
@@ -303,14 +287,14 @@ describe('WordPress API Module', () => {
 
       it('should send request body as JSON', async () => {
         restoreEnv = mockEnv({
-          WP_API_URL: 'https://example.com',
+          WP_API_URL: 'https://my-wp-site.com',
           JWT_TOKEN: 'test-token',
         });
 
         const requestParams = { method: 'tools/list', cursor: 'abc123' };
-        
-        nock('https://example.com')
-          .post('/?rest_route=/wp/v2/mcp/v1', requestParams)
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, requestParams)
           .reply(200, { status: 'success' });
 
         const { wpRequest } = await import('../../src/lib/wordpress-api.js');
@@ -321,17 +305,17 @@ describe('WordPress API Module', () => {
 
       it('should handle successful API responses', async () => {
         restoreEnv = mockEnv({
-          WP_API_URL: 'https://example.com',
+          WP_API_URL: 'https://my-wp-site.com',
           JWT_TOKEN: 'test-token',
         });
 
-        const expectedResponse = { 
-          status: 'success', 
-          data: { tools: ['tool1', 'tool2'] } 
+        const expectedResponse = {
+          status: 'success',
+          data: { tools: ['tool1', 'tool2'] }
         };
-        
-        nock('https://example.com')
-          .post('/?rest_route=/wp/v2/mcp/v1')
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT)
           .reply(200, expectedResponse);
 
         const { wpRequest } = await import('../../src/lib/wordpress-api.js');
@@ -344,16 +328,16 @@ describe('WordPress API Module', () => {
     describe('Error handling', () => {
       it('should throw APIError for HTTP error responses', async () => {
         restoreEnv = mockEnv({
-          WP_API_URL: 'https://example.com',
+          WP_API_URL: 'https://my-wp-site.com',
           JWT_TOKEN: 'test-token',
         });
 
-        nock('https://example.com')
-          .post('/?rest_route=/wp/v2/mcp/v1')
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT)
           .reply(401, 'Unauthorized');
 
         const { wpRequest } = await import('../../src/lib/wordpress-api.js');
-        
+
         await expect(wpRequest({ method: 'initialize' })).rejects.toThrow(
           'WordPress API error (401): Unauthorized'
         );
@@ -361,16 +345,16 @@ describe('WordPress API Module', () => {
 
       it('should throw APIError for network errors', async () => {
         restoreEnv = mockEnv({
-          WP_API_URL: 'https://example.com',
+          WP_API_URL: 'https://my-wp-site.com',
           JWT_TOKEN: 'test-token',
         });
 
-        nock('https://example.com')
-          .post('/?rest_route=/wp/v2/mcp/v1')
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT)
           .replyWithError('Network error');
 
         const { wpRequest } = await import('../../src/lib/wordpress-api.js');
-        
+
         await expect(wpRequest({ method: 'initialize' })).rejects.toThrow(
           'Network error'
         );
@@ -378,33 +362,33 @@ describe('WordPress API Module', () => {
 
       it('should throw APIError for invalid JSON responses', async () => {
         restoreEnv = mockEnv({
-          WP_API_URL: 'https://example.com',
+          WP_API_URL: 'https://my-wp-site.com',
           JWT_TOKEN: 'test-token',
         });
 
-        nock('https://example.com')
-          .post('/?rest_route=/wp/v2/mcp/v1')
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT)
           .reply(200, 'invalid json');
 
         const { wpRequest } = await import('../../src/lib/wordpress-api.js');
-        
+
         await expect(wpRequest({ method: 'initialize' })).rejects.toThrow();
       });
     });
 
     describe('Default parameters', () => {
-      it('should handle default parameters when none provided', async () => {
+      it('should handle minimal request data', async () => {
         restoreEnv = mockEnv({
-          WP_API_URL: 'https://example.com',
+          WP_API_URL: 'https://my-wp-site.com',
           JWT_TOKEN: 'test-token',
         });
 
-        nock('https://example.com')
-          .post('/?rest_route=/wp/v2/mcp/v1', { method: 'init' })
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, { method: 'init' })
           .reply(200, { status: 'success' });
 
         const { wpRequest } = await import('../../src/lib/wordpress-api.js');
-        await wpRequest();
+        await wpRequest({ method: 'init' });
 
         expect(nock.isDone()).toBe(true);
       });
@@ -412,62 +396,29 @@ describe('WordPress API Module', () => {
   });
 
   describe('Helper functions', () => {
-    describe('removeTrailingSlash', () => {
-      it('should be tested through URL construction', async () => {
-        // This function is private but tested through wpRequest behavior
+    describe('constructApiUrl', () => {
+      it.each([
+        ['bare domain', 'https://my-wp-site.com', WP_MCP_ENDPOINT],
+        ['API subdomain', 'https://api.mysite.com', WP_MCP_ENDPOINT],
+        ['custom path', 'https://my-wp-site.com/custom', '/custom'],
+      ])('routes %s (%s) to correct endpoint', async (_label, url, expectedPath) => {
         restoreEnv = mockEnv({
-          WP_API_URL: 'https://example.com//',
+          WP_API_URL: url,
           JWT_TOKEN: 'test-token',
         });
 
-        nock('https://example.com')
-          .post('/?rest_route=/wp/v2/mcp/v1')
+        const urlObj = new URL(url);
+        nock(`${urlObj.protocol}//${urlObj.host}`)
+          .post(expectedPath)
           .reply(200, { status: 'success' });
 
+        jest.resetModules();
         const { wpRequest } = await import('../../src/lib/wordpress-api.js');
         await wpRequest({ method: 'initialize' });
 
         expect(nock.isDone()).toBe(true);
-      });
-    });
-
-    describe('constructApiUrl', () => {
-      it('should handle various URL formats correctly through wpRequest', async () => {
-        // Testing different URL construction scenarios through wpRequest
-        const testCases = [
-          {
-            url: 'https://example.com',
-            expectedPath: '/?rest_route=/wp/v2/mcp/v1'
-          },
-          {
-            url: 'https://api.mysite.com',
-            expectedPath: '/?rest_route=/wp/v2/mcp/v1'
-          },
-          {
-            url: 'https://example.com/custom',
-            expectedPath: '/custom'
-          }
-        ];
-
-        for (const testCase of testCases) {
-          restoreEnv = mockEnv({
-            WP_API_URL: testCase.url,
-            JWT_TOKEN: 'test-token',
-          });
-
-          const urlObj = new URL(testCase.url);
-          nock(`${urlObj.protocol}//${urlObj.host}`)
-            .post(testCase.expectedPath)
-            .reply(200, { status: 'success' });
-
-          jest.resetModules();
-          const { wpRequest } = await import('../../src/lib/wordpress-api.js');
-          await wpRequest({ method: 'initialize' });
-
-          expect(nock.isDone()).toBe(true);
-          nock.cleanAll();
-          if (restoreEnv) restoreEnv();
-        }
+        nock.cleanAll();
+        if (restoreEnv) restoreEnv();
       });
     });
   });
@@ -475,16 +426,16 @@ describe('WordPress API Module', () => {
   describe('OAuth token management', () => {
     it('should handle getOAuthTokens when OAuth is disabled', async () => {
       restoreEnv = mockEnv({
-        WP_API_URL: 'https://example.com',
+        WP_API_URL: 'https://my-wp-site.com',
         OAUTH_ENABLED: 'false',
         WP_API_USERNAME: 'testuser',
         WP_API_PASSWORD: 'testpass',
       });
 
       const expectedAuth = Buffer.from('testuser:testpass').toString('base64');
-      
-      nock('https://example.com')
-        .post('/?rest_route=/wp/v2/mcp/v1')
+
+      nock('https://my-wp-site.com')
+        .post(WP_MCP_ENDPOINT)
         .matchHeader('authorization', `Basic ${expectedAuth}`)
         .reply(200, { status: 'success' });
 


### PR DESCRIPTION
## Summary

- **Bug:** In 0.2.20, `tools/list` could fire before transport detection completed, causing `prepareRequest` to skip the JSON-RPC envelope. WordPress rejected these with `"jsonrpc version must be '2.0'"`.
- **Root cause:** A drive-by change in the fallback init response (`tools: {}` → `tools: { listChanged: false }`) told the MCP SDK to request tools on a dead connection. Combined with no init gate on handlers, `transportType` was still `null` when `tools/list` ran.
- **Fix:** Added `waitForInit()` gate with 30s timeout. All handlers block until transport detection settles. Init failure returns a clean MCP error instead of forwarding malformed requests.
- **Tests:** 10 unit tests (gate blocking, timeout, failure, concurrent handlers, race condition regression) + 1 integration test (spawns built proxy against dead backend over stdio).
- **Test cleanup:** Deleted 15 duplicate/framework-tester tests, rewrote 3 with smells. 164 tests, all passing.
- **Smoke tested** against packed tarball (`npm pack`) with both healthy and dead WordPress mock backends.

## Test plan

- [x] `npm run build` passes
- [x] `npx jest --no-coverage` — 164 tests, 9 suites, all green
- [x] `mcp-canary-smoke.sh` — healthy backend: JSON-RPC envelope present; dead backend: no outbound `tools/list`, clean MCP error returned
- [ ] Publish canary (`0.2.21-canary.1`), run smoke test via `npx @automattic/mcp-wordpress-remote@canary`
- [ ] Soak canary in real client environment
- [ ] Promote to `latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)