### PR TITLE
Fix bin entry: use unscoped name and relative path

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     }
   },
   "bin": {
-    "@automattic/mcp-wordpress-remote": "dist/proxy.js"
+    "mcp-wordpress-remote": "./dist/proxy.js"
   },
   "scripts": {
     "build": "tsup",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,7 +4,7 @@ import { selectCallbackPort } from './port-utils.js';
 import { logger } from './utils.js';
 
 // Version constant - update this manually when releasing new versions
-export const MCP_WORDPRESS_REMOTE_VERSION = '0.2.19';
+export const MCP_WORDPRESS_REMOTE_VERSION = '0.2.21';
 
 /**
  * Centralized configuration for MCP WordPress Remote


### PR DESCRIPTION
## Summary

- Use `mcp-wordpress-remote` instead of `@automattic/mcp-wordpress-remote` as bin key
- Add `./` prefix to `dist/proxy.js`

npm auto-corrects both at publish time, so this is cosmetic — eliminates the publish warnings.

## Test plan

- [ ] `npm pack --dry-run` shows no bin warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)