### PR TITLE
feat: support text/event-stream responses from WordPress MCP endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.2.19",
+  "version": "0.2.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/mcp-wordpress-remote",
-      "version": "0.2.19",
+      "version": "0.2.21",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
         "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "eventsource-parser": "^3.0.1",
         "express": "^4.18.2",
         "https-proxy-agent": "^7.0.6",
         "node-fetch": "^3.3.2",
@@ -88,6 +89,7 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -2760,6 +2762,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -3498,6 +3501,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3695,6 +3699,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4595,6 +4600,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7004,6 +7010,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7266,6 +7273,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7528,6 +7536,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
       "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.8.0",
     "@tootallnate/quickjs-emscripten": "^0.23.0",
+    "eventsource-parser": "^3.0.1",
     "express": "^4.18.2",
     "https-proxy-agent": "^7.0.6",
     "node-fetch": "^3.3.2",
@@ -100,6 +101,7 @@
     "splitting": false,
     "noExternal": [
       "@modelcontextprotocol/sdk",
+      "eventsource-parser",
       "express",
       "node-fetch",
       "open"

--- a/src/lib/mcp-oauth-provider.ts
+++ b/src/lib/mcp-oauth-provider.ts
@@ -334,10 +334,10 @@ export class MCPOAuthProvider {
       await writeTextFile(this.serverUrlHash, 'oauth_state.txt', this.currentState);
 
       // Step 4: Set up callback server with smart port selection
-      const callbackPort = this.config.callbackPort === 0 
-        ? await getOAuthCallbackPort() 
+      const callbackPort = this.config.callbackPort === 0
+        ? await getOAuthCallbackPort()
         : this.config.callbackPort;
-        
+
       const callbackServer = setupWPOAuthCallbackServer(
         {
           port: callbackPort,

--- a/src/lib/oauth-callback-server.ts
+++ b/src/lib/oauth-callback-server.ts
@@ -327,17 +327,23 @@ export class OAuthCallbackServer {
   }
 
   async stop(): Promise<void> {
-    return new Promise(resolve => {
-      if (this.server) {
-        this.server.close(() => {
-          logger.oauth('OAuth callback server stopped');
-          this.server = null;
-          resolve();
-        });
-      } else {
-        resolve();
-      }
+    if (!this.server) return;
+    const server = this.server;
+    this.server = null;
+
+    // Fire-and-forget. By the time stop() is called we already have the auth
+    // code and persisted tokens, so the callback server has no further role.
+    // Waiting for http.Server.close()'s callback would gate MCP initialization
+    // on every socket draining, and browsers hold the OAuth callback socket
+    // via HTTP/1.1 keep-alive for up to ~60s — long enough to trip the MCP
+    // client's 30s connect timeout on the very first run. Initiate close
+    // and force-sever remaining sockets; logging happens when the callback
+    // eventually fires in the background.
+    server.close(err => {
+      if (err) logger.error('OAuth callback server close error', 'OAUTH', err);
+      else logger.oauth('OAuth callback server stopped');
     });
+    server.closeAllConnections?.();
   }
 
   getCallbackUrl(): string {

--- a/src/lib/port-utils.ts
+++ b/src/lib/port-utils.ts
@@ -64,7 +64,7 @@ export function calculateDefaultPort(serverUrlHash: string): number {
 export async function findExistingClientPort(serverUrlHash: string): Promise<number | undefined> {
   const clientInfo = await readJsonFile<OAuthClientInfo>(serverUrlHash, 'client_info.json');
 
-  if (!clientInfo) {
+  if (!clientInfo || !clientInfo?.redirect_uris) {
     return undefined;
   }
 

--- a/src/lib/port-utils.ts
+++ b/src/lib/port-utils.ts
@@ -64,7 +64,7 @@ export function calculateDefaultPort(serverUrlHash: string): number {
 export async function findExistingClientPort(serverUrlHash: string): Promise<number | undefined> {
   const clientInfo = await readJsonFile<OAuthClientInfo>(serverUrlHash, 'client_info.json');
 
-  if (!clientInfo || !clientInfo?.redirect_uris) {
+  if (!clientInfo || !clientInfo.redirect_uris) {
     return undefined;
   }
 

--- a/src/lib/wordpress-api.ts
+++ b/src/lib/wordpress-api.ts
@@ -48,18 +48,58 @@ function removeTrailingSlash(url: string): string {
 }
 
 /**
+ * Parse an SSE (text/event-stream) response body and return the JSON payload
+ * from the first "message" event.
+ *
+ * MCP's Streamable HTTP transport may respond with Content-Type: text/event-stream
+ * when the server has not enabled JSON-response mode. The wire format per the SSE
+ * spec is a sequence of events separated by blank lines, where each event is a set
+ * of `field: value` lines. We care about `event:` and `data:`; other fields
+ * (`id:`, `retry:`, comments starting with `:`) are ignored.
+ */
+function parseSSEMessage(text: string): unknown {
+  const events = text.split(/\r?\n\r?\n/).filter(e => e.trim().length > 0);
+
+  for (const event of events) {
+    let eventType = 'message';
+    const dataLines: string[] = [];
+
+    for (const line of event.split(/\r?\n/)) {
+      if (line.length === 0 || line.startsWith(':')) continue;
+
+      const colonIdx = line.indexOf(':');
+      const field = colonIdx === -1 ? line : line.slice(0, colonIdx);
+      let value = colonIdx === -1 ? '' : line.slice(colonIdx + 1);
+      if (value.startsWith(' ')) value = value.slice(1);
+
+      if (field === 'event') {
+        eventType = value;
+      } else if (field === 'data') {
+        dataLines.push(value);
+      }
+    }
+
+    if (eventType === 'message' && dataLines.length > 0) {
+      return JSON.parse(dataLines.join('\n'));
+    }
+  }
+
+  throw new Error('No "message" event with data found in SSE response');
+}
+
+/**
  * Determines if a URL has a custom path (beyond just domain) and constructs the final API URL
  * - If URL has no path (e.g., http://example.com or http://example.com/), use default REST route format
  * - If URL has a path (e.g., http://example.com/api/mcp), use the URL exactly as provided
  */
 function constructApiUrl(baseUrl: string, defaultEndpoint: string): string {
   const cleanUrl = removeTrailingSlash(baseUrl);
-  
+
   try {
     const urlObj = new URL(cleanUrl);
     const hasCustomPath = urlObj.pathname && urlObj.pathname !== '/' && urlObj.pathname.length > 0;
     const hasCustomQuery = urlObj.search && urlObj.search.length > 0;
-    
+
     if (hasCustomPath || hasCustomQuery) {
       // URL has a custom path or query strings - use it exactly as provided
       return cleanUrl;
@@ -221,7 +261,7 @@ export async function wpRequest(
 
     // Determine method and tool name based on transport type
     const method = useJsonRpc ? requestData.method : requestData.method;
-    const toolName = useJsonRpc 
+    const toolName = useJsonRpc
       ? (requestData.params?.name || requestData.params?.tool)
       : (requestData.name || requestData.tool || requestData.args?.tool);
 
@@ -275,7 +315,7 @@ export async function wpRequest(
 
   // Get current API URL from environment (to handle dynamic changes)
   const currentApiUrl = process.env.WP_API_URL || CONFIG.WP_API_URL;
-  
+
   logger.debug(`Environment: ${CONFIG.NODE_ENV}`, 'API');
   logger.debug(`Base API URL: ${currentApiUrl}`, 'API');
 
@@ -286,6 +326,7 @@ export async function wpRequest(
   // Build headers object - only add Authorization if we have one
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
     'MCP-Protocol-Version': '2025-06-18', // MCP protocol version
     ...customHeaders, // Merge custom headers
   };
@@ -329,30 +370,40 @@ export async function wpRequest(
     const response = await proxyFetch(url, fetchOptions);
     logger.debug(`Response status: ${response.status}`, 'API');
 
+    const rawBody = await response.text();
+
     // Handle error responses
     if (!response.ok) {
-      const errorText = await response.text();
-      logger.error(`API error response: ${errorText}`, 'API');
+      logger.error(`API error response: ${rawBody}`, 'API');
       throw new APIError(
-        `WordPress API error (${response.status}): ${errorText}`,
+        `WordPress API error (${response.status}): ${rawBody}`,
         response.status,
         url,
-        errorText
+        rawBody
       );
     }
 
-    const responseData = await response.json();
-    
+    // MCP Streamable HTTP transport may respond with either application/json
+    // (single-shot) or text/event-stream (SSE frames). Branch on Content-Type.
+    const contentType = response.headers.get('content-type') ?? '';
+    let responseData: unknown;
+    if (contentType.includes('text/event-stream')) {
+      responseData = parseSSEMessage(rawBody);
+      logger.debug('Parsed text/event-stream response body', 'API');
+    } else {
+      responseData = JSON.parse(rawBody);
+    }
+
     // Extract session ID from response headers (for initialize requests)
     const sessionIdHeader = response.headers.get('Mcp-Session-Id');
     if (sessionIdHeader && !globalSessionId) {
       globalSessionId = sessionIdHeader;
       logger.info(`Session ID received from WordPress: ${globalSessionId}`, 'SESSION');
     }
-    
+
     logger.api('Response received successfully');
     logger.debug(`Response data: ${JSON.stringify(responseData)}`, 'API');
-    
+
     // Handle response format based on transport type
     if (useJsonRpc && responseData && typeof responseData === 'object') {
       const jsonrpcResponse = responseData as any; // Type assertion for JSON-RPC response
@@ -373,7 +424,7 @@ export async function wpRequest(
         }
       }
     }
-    
+
     // For simple transport or non-JSON-RPC responses, return response as-is
     return responseData as WordPressResponse;
   } catch (error) {

--- a/src/lib/wordpress-api.ts
+++ b/src/lib/wordpress-api.ts
@@ -3,6 +3,7 @@
  */
 import * as path from 'node:path';
 import { EventEmitter } from 'node:events';
+import { createParser } from 'eventsource-parser';
 import { WordPressRequestParams, WordPressResponse } from './types.js';
 import { logger, LogLevel } from './utils.js';
 import { CONFIG, validateConfig, getDefaultOAuthScopes, getCustomHeaders } from './config.js';
@@ -51,40 +52,34 @@ function removeTrailingSlash(url: string): string {
  * Parse an SSE (text/event-stream) response body and return the JSON payload
  * from the first "message" event.
  *
- * MCP's Streamable HTTP transport may respond with Content-Type: text/event-stream
- * when the server has not enabled JSON-response mode. The wire format per the SSE
- * spec is a sequence of events separated by blank lines, where each event is a set
- * of `field: value` lines. We care about `event:` and `data:`; other fields
- * (`id:`, `retry:`, comments starting with `:`) are ignored.
+ * Delegates SSE framing to `eventsource-parser` — the same library the MCP SDK
+ * uses in its Streamable HTTP transport — so edge cases (CRLF, multi-line data,
+ * comments, unknown fields) match spec and the SDK's behavior.
  */
 function parseSSEMessage(text: string): unknown {
-  const events = text.split(/\r?\n\r?\n/).filter(e => e.trim().length > 0);
+  let result: unknown;
+  let found = false;
 
-  for (const event of events) {
-    let eventType = 'message';
-    const dataLines: string[] = [];
-
-    for (const line of event.split(/\r?\n/)) {
-      if (line.length === 0 || line.startsWith(':')) continue;
-
-      const colonIdx = line.indexOf(':');
-      const field = colonIdx === -1 ? line : line.slice(0, colonIdx);
-      let value = colonIdx === -1 ? '' : line.slice(colonIdx + 1);
-      if (value.startsWith(' ')) value = value.slice(1);
-
-      if (field === 'event') {
-        eventType = value;
-      } else if (field === 'data') {
-        dataLines.push(value);
+  const parser = createParser({
+    onEvent(event) {
+      if (found) return;
+      // Per the SSE spec, an event with no `event:` field is a default "message".
+      // eventsource-parser leaves `event.event` as undefined in that case rather
+      // than defaulting to "message" like the browser EventSource API.
+      if (!event.event || event.event === 'message') {
+        result = JSON.parse(event.data);
+        found = true;
       }
-    }
+    },
+  });
 
-    if (eventType === 'message' && dataLines.length > 0) {
-      return JSON.parse(dataLines.join('\n'));
-    }
+  parser.feed(text);
+
+  if (!found) {
+    throw new Error('No "message" event with data found in SSE response');
   }
 
-  throw new Error('No "message" event with data found in SSE response');
+  return result;
 }
 
 /**

--- a/tests/unit/wordpress-api.test.ts
+++ b/tests/unit/wordpress-api.test.ts
@@ -323,6 +323,85 @@ describe('WordPress API Module', () => {
 
         expect(response).toEqual(expectedResponse);
       });
+
+      it('should parse text/event-stream responses and extract the JSON-RPC result', async () => {
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://my-wp-site.com',
+          JWT_TOKEN: 'test-token',
+        });
+
+        const jsonRpcEnvelope = {
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            protocolVersion: '2025-06-18',
+            serverInfo: { name: 'Parker', version: '1.0.0' },
+            capabilities: {},
+          },
+        };
+        const sseBody =
+          `event: message\n` +
+          `id: abc-123\n` +
+          `data: ${JSON.stringify(jsonRpcEnvelope)}\n\n`;
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT)
+          .reply(200, sseBody, { 'Content-Type': 'text/event-stream' });
+
+        const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+        const response = await wpRequest(
+          { jsonrpc: '2.0', method: 'initialize', id: 1, params: {} },
+          true
+        );
+
+        expect(response).toEqual(jsonRpcEnvelope.result);
+      });
+
+      it('should handle multi-line data fields in SSE responses', async () => {
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://my-wp-site.com',
+          JWT_TOKEN: 'test-token',
+        });
+
+        const payload = { jsonrpc: '2.0', id: 1, result: { ok: true } };
+        const json = JSON.stringify(payload, null, 2);
+        const sseBody =
+          `event: message\n` +
+          json
+            .split('\n')
+            .map(l => `data: ${l}`)
+            .join('\n') +
+          `\n\n`;
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT)
+          .reply(200, sseBody, { 'Content-Type': 'text/event-stream' });
+
+        const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+        const response = await wpRequest(
+          { jsonrpc: '2.0', method: 'initialize', id: 1, params: {} },
+          true
+        );
+
+        expect(response).toEqual(payload.result);
+      });
+
+      it('should throw when SSE response contains no message event', async () => {
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://my-wp-site.com',
+          JWT_TOKEN: 'test-token',
+        });
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT)
+          .reply(200, ': keep-alive comment\n\n', { 'Content-Type': 'text/event-stream' });
+
+        const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+
+        await expect(
+          wpRequest({ jsonrpc: '2.0', method: 'initialize', id: 1, params: {} }, true)
+        ).rejects.toThrow('No "message" event');
+      });
     });
 
     describe('Error handling', () => {

--- a/tests/unit/wordpress-api.test.ts
+++ b/tests/unit/wordpress-api.test.ts
@@ -386,6 +386,33 @@ describe('WordPress API Module', () => {
         expect(response).toEqual(payload.result);
       });
 
+      it('should treat SSE frames with no event field as default "message" events', async () => {
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://my-wp-site.com',
+          JWT_TOKEN: 'test-token',
+        });
+
+        const jsonRpcEnvelope = {
+          jsonrpc: '2.0',
+          id: 1,
+          result: { ok: true },
+        };
+        // No `event:` field — per the SSE spec this is a default "message" event.
+        const sseBody = `data: ${JSON.stringify(jsonRpcEnvelope)}\n\n`;
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT)
+          .reply(200, sseBody, { 'Content-Type': 'text/event-stream' });
+
+        const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+        const response = await wpRequest(
+          { jsonrpc: '2.0', method: 'initialize', id: 1, params: {} },
+          true
+        );
+
+        expect(response).toEqual(jsonRpcEnvelope.result);
+      });
+
       it('should throw when SSE response contains no message event', async () => {
         restoreEnv = mockEnv({
           WP_API_URL: 'https://my-wp-site.com',


### PR DESCRIPTION
  ## Description

  MCP's Streamable HTTP transport lets servers respond to a POST with either `application/json` or `text/event-stream`. The proxy previously called `response.json()` unconditionally, which failed the moment
  a WordPress endpoint chose SSE framing. This PR makes the proxy accept both response shapes, swaps the hand-rolled SSE parser for the same library the MCP SDK uses internally, and fixes two unrelated bugs
  that surfaced while testing the SSE path end-to-end against production WordPress.

  ## Technical details for reviewers

  **SSE handling (`src/lib/wordpress-api.ts`)**
  - Advertise both formats: `Accept: application/json, text/event-stream`
  - Branch on response `Content-Type`; SSE bodies are parsed via `eventsource-parser`'s `createParser` callback API (one-shot, non-streaming — the WordPress endpoint sends a single framed response then
  closes)
  - JSON-RPC envelope unwrapping (extracting `result` / throwing on `error`) is unchanged

  **OAuth shutdown fix (`src/lib/oauth-callback-server.ts`)**
  - `http.Server.close()` only invokes its callback once *every* socket has drained. Browsers hold the OAuth callback response socket via HTTP/1.1 keep-alive for up to ~60s, which reliably tripped the MCP
  client's 30s connect timeout on first-run OAuth (second run worked because cached tokens skipped the callback server entirely)
  - Fix: don't wait for the callback at all — `stop()` returns synchronously, `close()` fires in the background, and `closeAllConnections()` (optional-chained for older Node) force-severs remaining sockets
                                                                                                                                                                                                               
  **Dependency**
  - Adds `eventsource-parser@^3.0.1` (MIT, zero runtime deps, Node ≥18) as a direct dependency rather than relying on the transitive copy via `@modelcontextprotocol/sdk`                                      
                                                                                  