### PR TITLE
Fix token dir "wordpress-remote-undefined" suffix

### DIFF
--- a/src/lib/persistent-auth-config.ts
+++ b/src/lib/persistent-auth-config.ts
@@ -7,9 +7,6 @@ import { logger } from './utils.js';
 import { CONFIG, MCP_WORDPRESS_REMOTE_VERSION } from './config.js';
 import { WPTokens, WPClientInfo, TokenValidationResult, LockfileData } from './oauth-types.js';
 
-// Use version from config for directory naming
-const VERSION = MCP_WORDPRESS_REMOTE_VERSION;
-
 /**
  * WordPress MCP Remote Authentication Configuration
  *
@@ -71,8 +68,9 @@ export async function deleteLockfile(serverUrlHash: string): Promise<void> {
  */
 export function getConfigDir(): string {
   const baseConfigDir = CONFIG.WP_MCP_CONFIG_DIR;
-  // Add a version subdirectory so we don't need to worry about backwards/forwards compatibility
-  return path.join(baseConfigDir, `wordpress-remote-${VERSION}`);
+  // Version read at call-time: tsup flattens ESM and emits top-level `const` as `var`,
+  // which breaks TDZ and causes a module-top-level capture to resolve `undefined`.
+  return path.join(baseConfigDir, `wordpress-remote-${MCP_WORDPRESS_REMOTE_VERSION}`);
 }
 
 /**

--- a/tests/integration/bundle-version-interpolation.test.ts
+++ b/tests/integration/bundle-version-interpolation.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Smoke test against the built tsup bundle.
+ *
+ * Source-level unit tests cannot catch this class of bug: ESM semantics in
+ * source preserve TDZ and live bindings, so a module-top-level
+ * `const VERSION = MCP_WORDPRESS_REMOTE_VERSION;` works fine under ts-jest.
+ * Once tsup flattens multiple ESM modules into a single file and emits
+ * top-level `const` as `var`, the guarantee is lost: if the capturing module
+ * is ordered before the defining module, `VERSION` resolves to `undefined`
+ * and the config directory becomes `wordpress-remote-undefined/`.
+ *
+ * This test asserts the bundle does not contain the broken capture pattern
+ * and does interpolate the version identifier directly inside the template.
+ * Requires `npm run build` to have produced `dist/proxy.js`.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const bundlePath = path.resolve(__dirname, '../../dist/proxy.js');
+const bundleExists = fs.existsSync(bundlePath);
+
+if (!bundleExists) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[bundle-version-interpolation] Skipping: ${bundlePath} not found. Run \`npm run build\` first.`
+  );
+}
+
+const describeIfBuilt = bundleExists ? describe : describe.skip;
+
+describeIfBuilt('built bundle: version interpolation in getConfigDir', () => {
+  let bundleSource: string;
+
+  beforeAll(() => {
+    bundleSource = fs.readFileSync(bundlePath, 'utf-8');
+  });
+
+  it('does not capture MCP_WORDPRESS_REMOTE_VERSION at module top level', () => {
+    // The pre-fix pattern. tsup emitted `var VERSION = MCP_WORDPRESS_REMOTE_VERSION`
+    // at line 35881 while `var MCP_WORDPRESS_REMOTE_VERSION = "x.y.z"` landed later
+    // at line 36142. Hoisting made the capture resolve to `undefined`.
+    expect(bundleSource).not.toMatch(/var\s+VERSION\s*=\s*MCP_WORDPRESS_REMOTE_VERSION/);
+  });
+
+  it('interpolates MCP_WORDPRESS_REMOTE_VERSION directly into the config dir template', () => {
+    expect(bundleSource).toMatch(/wordpress-remote-\$\{MCP_WORDPRESS_REMOTE_VERSION\}/);
+  });
+});


### PR DESCRIPTION
## Summary

OAuth tokens were being persisted under `~/.mcp-auth/wordpress-remote-undefined/` instead of `~/.mcp-auth/wordpress-remote-<version>/`, defeating the version-subdir scheme that exists to isolate storage across upgrades. Every released version since `405556d` (2025-09-09) has shipped with this bug — confirmed live on 0.2.21.

## Root cause

`tsup` flattens ESM modules into a single bundle and emits top-level `const` as `var`. In `dist/proxy.js`:

- Line 35881: `var VERSION = MCP_WORDPRESS_REMOTE_VERSION;`
- Line 36142: `var MCP_WORDPRESS_REMOTE_VERSION = "0.2.21";`

`var` declarations hoist but assignments do not, so at the time the first statement runs, `MCP_WORDPRESS_REMOTE_VERSION` is still `undefined`. The captured `VERSION` is `undefined` forever after.

Source-level ESM would have enforced TDZ and preserved the live binding, but the bundler's `var` emission discards that guarantee. This is why the existing unit tests in `tests/unit/persistent-auth-config.test.ts` pass under ts-jest — source-level semantics hold — but the built artifact is broken.

## Fix

Move the `MCP_WORDPRESS_REMOTE_VERSION` read from module top level into the body of `getConfigDir()` so it resolves at call-time, after all bundled `var` initializers have run.

## Tests

Added `tests/integration/bundle-version-interpolation.test.ts` — reads `dist/proxy.js` and asserts:
1. The broken `var VERSION = MCP_WORDPRESS_REMOTE_VERSION` capture pattern is absent.
2. The template interpolates `MCP_WORDPRESS_REMOTE_VERSION` directly.

Skips (with a `console.warn`) when `dist/proxy.js` is missing so `npm run test:integration` on a fresh checkout still exits green. Source-level tests cannot catch this class of bundling bug — only the built artifact reproduces it.

## Test plan

- [ ] `npm run build` then `grep "wordpress-remote-" dist/proxy.js` shows only the fixed interpolation, no stale `VERSION` reference.
- [ ] Running the proxy creates `~/.mcp-auth/wordpress-remote-<current-version>/` (not `wordpress-remote-undefined/`).
- [ ] `npx jest tests/unit/persistent-auth-config.test.ts` — 38/38 pass.
- [ ] `npx jest tests/integration/bundle-version-interpolation.test.ts` after `npm run build` — 2/2 pass.
- [ ] `rm -rf dist && npx jest tests/integration/bundle-version-interpolation.test.ts` — tests skip with warning, exit 0.

## Not in this PR

- Migration of existing `~/.mcp-auth/wordpress-remote-undefined/` tokens — users re-auth once after upgrading; migration code would add two change points for a directory that should never have existed.
- Repo-wide prettier cleanup — 55 files (including pre-existing noise in this file's `isTokenValid()`) warn under `prettier --check .` on `trunk`. Out of scope here.
- A lint rule for the general class of "module-top-level capture of imported const". The smoke test covers regression for the one symptom that matters.