### PR TITLE
Recover from expired session errors

### DIFF
--- a/src/lib/wordpress-api.ts
+++ b/src/lib/wordpress-api.ts
@@ -32,6 +32,12 @@ let globalEvents: EventEmitter | null = null;
 
 // Global session ID received from WordPress server
 let globalSessionId: string | null = null;
+let lastInitializeRequest: { requestData: any; useJsonRpc: boolean } | null = null;
+let sessionRefreshPromise: Promise<void> | null = null;
+
+const WP_MCP_ENDPOINT = '/wp/v2/wpmcp';
+const INVALID_SESSION_ERROR_CODE = -32602;
+const INVALID_SESSION_ERROR_MESSAGE = 'Invalid or expired session';
 
 function validateEnvironment() {
   const validation = validateConfig();
@@ -171,14 +177,74 @@ export function getSessionId(): string | null {
   return globalSessionId;
 }
 
-export async function wpRequest(
-  requestData: any,
-  useJsonRpc: boolean = true
-): Promise<WordPressResponse> {
-  // Validate environment variables first
-  validateEnvironment();
+function getCurrentApiUrl(): string {
+  return process.env.WP_API_URL || CONFIG.WP_API_URL;
+}
 
-  const endpoint = '/wp/v2/wpmcp'; // WordPress MCP endpoint
+function getRequestUrl(): string {
+  return constructApiUrl(getCurrentApiUrl(), WP_MCP_ENDPOINT);
+}
+
+function cloneRequestData<T>(requestData: T): T {
+  return JSON.parse(JSON.stringify(requestData)) as T;
+}
+
+function isInitializeRequest(requestData: any): boolean {
+  return requestData?.method === 'initialize';
+}
+
+function cacheInitializeRequest(requestData: any, useJsonRpc: boolean): void {
+  lastInitializeRequest = {
+    requestData: cloneRequestData(requestData),
+    useJsonRpc,
+  };
+}
+
+function parseApiErrorResponse(error: APIError): any {
+  if (!error.response) {
+    return null;
+  }
+
+  if (typeof error.response === 'string') {
+    try {
+      return JSON.parse(error.response);
+    } catch {
+      return null;
+    }
+  }
+
+  return error.response;
+}
+
+function isInvalidSessionError(error: APIError): boolean {
+  const errorResponse = parseApiErrorResponse(error);
+  return (
+    errorResponse?.code === INVALID_SESSION_ERROR_CODE &&
+    errorResponse?.message === INVALID_SESSION_ERROR_MESSAGE
+  );
+}
+
+function updateSessionId(sessionId: string): void {
+  if (globalSessionId === sessionId) {
+    return;
+  }
+
+  globalSessionId = sessionId;
+  logger.info(`Session ID received from WordPress: ${globalSessionId}`, 'SESSION');
+}
+
+interface RequestExecutionResult {
+  responseData: WordPressResponse;
+  sessionIdUsed: string | null;
+}
+
+async function executeWordPressRequest(
+  requestData: any,
+  useJsonRpc: boolean,
+  sessionIdUsed: string | null
+): Promise<RequestExecutionResult> {
+  const url = getRequestUrl();
+
   const method = 'POST';
 
   // Log the request parameters for debugging
@@ -272,15 +338,9 @@ export async function wpRequest(
       'NO_AUTH_METHOD'
     );
   }
-
-  // Get current API URL from environment (to handle dynamic changes)
-  const currentApiUrl = process.env.WP_API_URL || CONFIG.WP_API_URL;
   
   logger.debug(`Environment: ${CONFIG.NODE_ENV}`, 'API');
-  logger.debug(`Base API URL: ${currentApiUrl}`, 'API');
-
-  // Construct the final API URL based on whether the base URL has a custom path
-  const url = constructApiUrl(currentApiUrl, endpoint);
+  logger.debug(`Base API URL: ${getCurrentApiUrl()}`, 'API');
   logger.debug(`Final requesting URL: ${url}`, 'API');
 
   // Build headers object - only add Authorization if we have one
@@ -295,10 +355,9 @@ export async function wpRequest(
     headers.Authorization = authHeader;
   }
 
-  // Add session ID header if available (for MCP compliance)
-  // Session ID will be set after we receive it from WordPress initialize response
-  if (globalSessionId) {
-    headers['Mcp-Session-Id'] = globalSessionId;
+  // Add session ID header if available for this request
+  if (sessionIdUsed) {
+    headers['Mcp-Session-Id'] = sessionIdUsed;
   }
 
   // Log authentication method being used
@@ -343,11 +402,10 @@ export async function wpRequest(
 
     const responseData = await response.json();
     
-    // Extract session ID from response headers (for initialize requests)
+    // Accept session updates whenever WordPress provides one.
     const sessionIdHeader = response.headers.get('Mcp-Session-Id');
-    if (sessionIdHeader && !globalSessionId) {
-      globalSessionId = sessionIdHeader;
-      logger.info(`Session ID received from WordPress: ${globalSessionId}`, 'SESSION');
+    if (sessionIdHeader) {
+      updateSessionId(sessionIdHeader);
     }
     
     logger.api('Response received successfully');
@@ -365,17 +423,23 @@ export async function wpRequest(
             `WordPress JSON-RPC error: ${jsonrpcResponse.error.message}`,
             jsonrpcResponse.error.code || 500,
             url,
-            JSON.stringify(jsonrpcResponse.error)
+            jsonrpcResponse.error
           );
         } else if (jsonrpcResponse.result !== undefined) {
           // Extract result from JSON-RPC response
-          return jsonrpcResponse.result as WordPressResponse;
+          return {
+            responseData: jsonrpcResponse.result as WordPressResponse,
+            sessionIdUsed,
+          };
         }
       }
     }
     
     // For simple transport or non-JSON-RPC responses, return response as-is
-    return responseData as WordPressResponse;
+    return {
+      responseData: responseData as WordPressResponse,
+      sessionIdUsed,
+    };
   } catch (error) {
     if (error instanceof APIError) {
       throw error;
@@ -384,5 +448,102 @@ export async function wpRequest(
     const errorMessage = error instanceof Error ? error.message : String(error);
     logger.error(`Error in wpRequest: ${errorMessage}`, 'API');
     throw new APIError(errorMessage, 0, url);
+  }
+}
+
+async function refreshSession(failedSessionId: string | null): Promise<void> {
+  if (failedSessionId && globalSessionId && globalSessionId !== failedSessionId) {
+    logger.info('Detected newer session while handling invalid-session error; skipping refresh', 'SESSION');
+    return;
+  }
+
+  if (sessionRefreshPromise) {
+    logger.info('Waiting for in-flight WordPress session refresh', 'SESSION');
+    await sessionRefreshPromise;
+    return;
+  }
+
+  if (!lastInitializeRequest) {
+    throw new APIError(
+      'Cannot refresh WordPress session before initialize has completed',
+      0,
+      getRequestUrl()
+    );
+  }
+
+  sessionRefreshPromise = (async () => {
+    logger.warn('WordPress session rejected; refreshing session via initialize', 'SESSION');
+    globalSessionId = null;
+
+    await executeWordPressRequest(
+      lastInitializeRequest.requestData,
+      lastInitializeRequest.useJsonRpc,
+      null
+    );
+
+    if (!globalSessionId) {
+      throw new APIError(
+        'WordPress initialize did not return a session ID during refresh',
+        0,
+        getRequestUrl()
+      );
+    }
+  })();
+
+  try {
+    await sessionRefreshPromise;
+  } finally {
+    sessionRefreshPromise = null;
+  }
+}
+
+export async function wpRequest(
+  requestData: any,
+  useJsonRpc: boolean = true,
+  options: { allowSessionRecovery?: boolean } = {}
+): Promise<WordPressResponse> {
+  // Validate environment variables first
+  validateEnvironment();
+
+  const allowSessionRecovery = options.allowSessionRecovery !== false;
+
+  if (isInitializeRequest(requestData)) {
+    cacheInitializeRequest(requestData, useJsonRpc);
+  }
+
+  const sessionIdUsed = globalSessionId;
+
+  try {
+    const result = await executeWordPressRequest(requestData, useJsonRpc, sessionIdUsed);
+    return result.responseData;
+  } catch (error) {
+    if (
+      error instanceof APIError &&
+      allowSessionRecovery &&
+      !isInitializeRequest(requestData) &&
+      isInvalidSessionError(error)
+    ) {
+      logger.warn('WordPress session expired; attempting one-time recovery', 'SESSION', {
+        method: requestData?.method || 'unknown',
+        sessionIdUsed: sessionIdUsed || 'none',
+      });
+
+      await refreshSession(sessionIdUsed);
+
+      const retriedResult = await executeWordPressRequest(
+        requestData,
+        useJsonRpc,
+        globalSessionId
+      );
+      return retriedResult.responseData;
+    }
+
+    if (error instanceof APIError) {
+      throw error;
+    }
+
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error(`Error in wpRequest: ${errorMessage}`, 'API');
+    throw new APIError(errorMessage, 0, getRequestUrl());
   }
 }

--- a/tests/unit/wordpress-api.test.ts
+++ b/tests/unit/wordpress-api.test.ts
@@ -32,6 +32,25 @@ jest.unstable_mockModule('../../src/lib/coordination.js', () => ({
 // The WordPress MCP endpoint used by the source code
 const WP_MCP_ENDPOINT = '/?rest_route=/wp/v2/wpmcp';
 
+function createJsonRpcResult(id: number, result: any) {
+  return {
+    jsonrpc: '2.0',
+    id,
+    result,
+  };
+}
+
+function createJsonRpcError(id: number, code: number, message: string) {
+  return {
+    jsonrpc: '2.0',
+    id,
+    error: {
+      code,
+      message,
+    },
+  };
+}
+
 describe('WordPress API Module', () => {
   let restoreEnv: () => void;
 
@@ -323,6 +342,177 @@ describe('WordPress API Module', () => {
 
         expect(response).toEqual(expectedResponse);
       });
+
+      it('should refresh the session once and retry the original request', async () => {
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://my-wp-site.com',
+          JWT_TOKEN: 'test-token',
+        });
+
+        const initializeRequest = {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            clientInfo: {
+              name: 'test-client',
+              version: '1.0.0',
+            },
+            _proxy_request_id: 1,
+          },
+        };
+        const toolRequest = {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/list',
+          params: {
+            cursor: 'abc123',
+          },
+        };
+        const promptRequest = {
+          jsonrpc: '2.0',
+          id: 3,
+          method: 'prompts/list',
+          params: {},
+        };
+
+        const initHeaders: Array<string | undefined> = [];
+        let initCallCount = 0;
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, initializeRequest)
+          .twice()
+          .reply(function () {
+            const header = this.req.headers['mcp-session-id'];
+            initHeaders.push(Array.isArray(header) ? header[0] : header as string | undefined);
+            initCallCount += 1;
+
+            return [
+              200,
+              createJsonRpcResult(1, { protocolVersion: '2025-06-18' }),
+              {
+                'Mcp-Session-Id': initCallCount === 1 ? 'session-1' : 'session-2',
+              },
+            ];
+          });
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, toolRequest)
+          .matchHeader('mcp-session-id', 'session-1')
+          .reply(200, createJsonRpcError(2, -32602, 'Invalid or expired session'));
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, toolRequest)
+          .matchHeader('mcp-session-id', 'session-2')
+          .reply(200, createJsonRpcResult(2, { tools: [{ name: 'posts-list' }] }));
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, promptRequest)
+          .matchHeader('mcp-session-id', 'session-2')
+          .reply(200, createJsonRpcResult(3, { prompts: [] }));
+
+        const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+
+        await wpRequest(initializeRequest, true);
+        await expect(wpRequest(toolRequest, true)).resolves.toEqual({
+          tools: [{ name: 'posts-list' }],
+        });
+        await expect(wpRequest(promptRequest, true)).resolves.toEqual({
+          prompts: [],
+        });
+
+        expect(initHeaders).toEqual([undefined, undefined]);
+        expect(nock.isDone()).toBe(true);
+      });
+
+      it('should reuse a shared refresh when stale-session errors resolve out of order', async () => {
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://my-wp-site.com',
+          JWT_TOKEN: 'test-token',
+        });
+
+        const initializeRequest = {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            clientInfo: {
+              name: 'test-client',
+              version: '1.0.0',
+            },
+            _proxy_request_id: 1,
+          },
+        };
+        const toolsRequest = {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/list',
+          params: {
+            cursor: 'first',
+          },
+        };
+        const promptsRequest = {
+          jsonrpc: '2.0',
+          id: 3,
+          method: 'prompts/list',
+          params: {},
+        };
+
+        let initCallCount = 0;
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, initializeRequest)
+          .twice()
+          .reply(function () {
+            const header = this.req.headers['mcp-session-id'];
+            expect(header).toBeUndefined();
+            initCallCount += 1;
+
+            return [
+              200,
+              createJsonRpcResult(1, { protocolVersion: '2025-06-18' }),
+              {
+                'Mcp-Session-Id': initCallCount === 1 ? 'session-1' : 'session-2',
+              },
+            ];
+          });
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, toolsRequest)
+          .matchHeader('mcp-session-id', 'session-1')
+          .reply(200, createJsonRpcError(2, -32602, 'Invalid or expired session'));
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, promptsRequest)
+          .matchHeader('mcp-session-id', 'session-1')
+          .delay(25)
+          .reply(200, createJsonRpcError(3, -32602, 'Invalid or expired session'));
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, toolsRequest)
+          .matchHeader('mcp-session-id', 'session-2')
+          .reply(200, createJsonRpcResult(2, { tools: [] }));
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, promptsRequest)
+          .matchHeader('mcp-session-id', 'session-2')
+          .reply(200, createJsonRpcResult(3, { prompts: [] }));
+
+        const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+
+        await wpRequest(initializeRequest, true);
+
+        await expect(
+          Promise.all([
+            wpRequest(toolsRequest, true),
+            wpRequest(promptsRequest, true),
+          ])
+        ).resolves.toEqual([
+          { tools: [] },
+          { prompts: [] },
+        ]);
+
+        expect(nock.isDone()).toBe(true);
+      });
     });
 
     describe('Error handling', () => {
@@ -373,6 +563,146 @@ describe('WordPress API Module', () => {
         const { wpRequest } = await import('../../src/lib/wordpress-api.js');
 
         await expect(wpRequest({ method: 'initialize' })).rejects.toThrow();
+      });
+
+      it('should not refresh the session for unrelated invalid-params errors', async () => {
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://my-wp-site.com',
+          JWT_TOKEN: 'test-token',
+        });
+
+        const initializeRequest = {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            clientInfo: {
+              name: 'test-client',
+              version: '1.0.0',
+            },
+            _proxy_request_id: 1,
+          },
+        };
+        const toolRequest = {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/list',
+          params: {
+            cursor: 'bad-cursor',
+          },
+        };
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, initializeRequest)
+          .reply(200, createJsonRpcResult(1, { protocolVersion: '2025-06-18' }), {
+            'Mcp-Session-Id': 'session-1',
+          });
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, toolRequest)
+          .matchHeader('mcp-session-id', 'session-1')
+          .reply(200, createJsonRpcError(2, -32602, 'Cursor is invalid'));
+
+        const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+
+        await wpRequest(initializeRequest, true);
+        await expect(wpRequest(toolRequest, true)).rejects.toThrow(
+          'WordPress JSON-RPC error: Cursor is invalid'
+        );
+
+        expect(nock.isDone()).toBe(true);
+      });
+
+      it('should not retry initialize requests when initialize itself returns an invalid session error', async () => {
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://my-wp-site.com',
+          JWT_TOKEN: 'test-token',
+        });
+
+        const initializeRequest = {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            clientInfo: {
+              name: 'test-client',
+              version: '1.0.0',
+            },
+            _proxy_request_id: 1,
+          },
+        };
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, initializeRequest)
+          .reply(200, createJsonRpcError(1, -32602, 'Invalid or expired session'));
+
+        const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+
+        await expect(wpRequest(initializeRequest, true)).rejects.toThrow(
+          'WordPress JSON-RPC error: Invalid or expired session'
+        );
+
+        expect(nock.isDone()).toBe(true);
+      });
+
+      it('should surface the invalid-session error after a single retry attempt', async () => {
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://my-wp-site.com',
+          JWT_TOKEN: 'test-token',
+        });
+
+        const initializeRequest = {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            clientInfo: {
+              name: 'test-client',
+              version: '1.0.0',
+            },
+            _proxy_request_id: 1,
+          },
+        };
+        const toolRequest = {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/list',
+          params: {},
+        };
+
+        let initCallCount = 0;
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, initializeRequest)
+          .twice()
+          .reply(function () {
+            initCallCount += 1;
+            return [
+              200,
+              createJsonRpcResult(1, { protocolVersion: '2025-06-18' }),
+              {
+                'Mcp-Session-Id': initCallCount === 1 ? 'session-1' : 'session-2',
+              },
+            ];
+          });
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, toolRequest)
+          .matchHeader('mcp-session-id', 'session-1')
+          .reply(200, createJsonRpcError(2, -32602, 'Invalid or expired session'));
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, toolRequest)
+          .matchHeader('mcp-session-id', 'session-2')
+          .reply(200, createJsonRpcError(2, -32602, 'Invalid or expired session'));
+
+        const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+
+        await wpRequest(initializeRequest, true);
+        await expect(wpRequest(toolRequest, true)).rejects.toThrow(
+          'WordPress JSON-RPC error: Invalid or expired session'
+        );
+
+        expect(nock.isDone()).toBe(true);
       });
     });
 


### PR DESCRIPTION
## Summary

This PR adds one-shot recovery for transient `Invalid or expired session` failures returned by the WordPress MCP backend.

It updates `wpRequest()` to:
- cache the last `initialize` payload so session refresh can replay the original transport-specific initialize request
- detect only the structured JSON-RPC `-32602 "Invalid or expired session"` error shape
- clear the stale session, run a single coordinated refresh initialize, and retry the original non-`initialize` request once
- avoid duplicate refreshes when parallel requests fail against the same stale session

## Why

We observed intermittent failures where `initialize` succeeded, but the immediate parallel follow-up calls (`tools/list`, `prompts/list`, `resources/list`) all failed with `Invalid or expired session`. A subsequent identical run succeeded, which points to a transient backend session-readiness or invalidation race rather than a deterministic auth failure.

Without recovery, that transient backend behavior surfaces as a hard MCP tool failure to the user.

## Validation

- `npx jest tests/unit/wordpress-api.test.ts --no-coverage`
- `npm run build`
- `npm ci && npm pack`
- installed the packed tarball in a clean temp directory and ran `npx mcp-wordpress-remote --help`
- real endpoint smoke against the `wpcom-pr51` config reached successful `initialize` and `tools/list`; the remaining failure was in Inspector tooling rather than in the proxy itself
