### PR TITLE
docs: rewrite README for mcp-adapter as primary plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# mcp-wordpress-remote
+
+MCP proxy server between Codex and a WordPress backend.
+
+## Commit discipline
+
+**Every line in a commit must trace to the stated goal.** No drive-by cleanups, no unrelated "improvements." The 0.2.20 race condition was caused by a harmless-looking capabilities change (`tools: {}` → `tools: { listChanged: false }`) bundled with an unrelated SOCKS proxy fix. Review every changed line — if it isn't required for the task, remove it before committing.
+
+## Pre-publish release gate
+
+"Works in repo" is not enough. Gate on "works from packed artifact in clean environment."
+
+1. Build and pack: `npm ci && npm run build && npm pack`
+2. Install tarball in a clean temp dir, run `npx mcp-wordpress-remote --help`
+3. Test against a healthy WordPress endpoint (normal init + tools/list flow)
+4. Test against a broken endpoint (fallback init, no malformed forwarding)
+5. Debug logs: verify no forwarded requests fire before init settles
+6. Publish canary first (`x.y.z-canary.1`), soak in real clients, then promote to latest
+7. Know the last good version — be ready for immediate dist-tag rollback
+
+## Testing
+
+- Run all tests: `npx jest tests/unit/ --no-coverage`
+- Build: `npm run build`
+- ESM mocking pattern: set `process.env` vars BEFORE `jest.resetModules()` + dynamic imports (CONFIG caches at import time)
+- WordPress API endpoint in nock: `/?rest_route=/wp/v2/wpmcp` (not `/wp/v2/wpmcp`)
+
+## Architecture notes
+
+- Transport detection (JSON-RPC vs simple) runs during the `initialize` handler
+- `sessionContext.transportType` starts null — the init-ready gate (`waitForInit`) blocks all handlers until detection settles
+- `waitForInit` returns `InitResult` (`{ ready: true } | { ready: false; reason: 'failed' | 'timeout' }`)

--- a/Docs/development.md
+++ b/Docs/development.md
@@ -15,7 +15,7 @@ npm install
 ```json
 {
   "mcpServers": {
-    "wordpress-mcp-server-name": {
+    "wordpress": {
       "command": "node",
       "args": ["/full-path-to-mcp-wordpress-remote/dist/proxy.js"],
       "env": {
@@ -24,7 +24,7 @@ npm install
         "WOO_CUSTOMER_KEY": "",
         "WOO_CUSTOMER_SECRET": "",
         "LOG_FILE": "optional full path to the log file",
-        "WP_API_URL": "http(s)://your-website-url.com/"
+        "WP_API_URL": "https://your-website-url.com/wp-json/mcp/mcp-adapter-default-server"
       }
     }
   }

--- a/Docs/oauth-implicit-flow.md
+++ b/Docs/oauth-implicit-flow.md
@@ -35,7 +35,7 @@ OAUTH_FLOW_TYPE=implicit
 OAUTH_USE_PKCE=false
 
 # Your WordPress site URL
-WP_API_URL=https://your-wordpress-site.com
+WP_API_URL=https://your-wordpress-site.com/wp-json/mcp/mcp-adapter-default-server
 
 # OAuth client ID from your WordPress site
 WP_OAUTH_CLIENT_ID=your_client_id
@@ -60,7 +60,7 @@ Example configuration:
 ```bash
 OAUTH_ENABLED=true
 OAUTH_FLOW_TYPE=implicit
-WP_API_URL=https://your-wordpress-site.com
+WP_API_URL=https://your-wordpress-site.com/wp-json/mcp/mcp-adapter-default-server
 WP_OAUTH_CLIENT_ID=12345
 OAUTH_CALLBACK_PORT=7665
 ```

--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -29,11 +29,11 @@ You can then update your MCP server configuration to use the full path for `npx`
 ```php
 {
 	"mcpServers": {
-		"wordpress-mcp": {
+		"wordpress": {
 			"command": "/Users/username/.nvm/versions/node/v22.16.0/bin/npx",
 			"args": [ "-y", "@automattic/mcp-wordpress-remote@latest" ],
 			"env": {
-				"WP_API_URL": "https://example.test/",
+				"WP_API_URL": "https://example.test/wp-json/mcp/mcp-adapter-default-server",
 				"JWT_TOKEN": "{your_jwt-token-here}",
 			}
 		}
@@ -50,12 +50,12 @@ You can work around this by setting the `NODE_TLS_REJECT_UNAUTHORIZED` environme
 ```php
 {
 	"mcpServers": {
-		"wordpress-mcp": {
+		"wordpress": {
 			"command": "/Users/username/.nvm/versions/node/v22.16.0/bin/npx",
 			"args": [ "-y", "@automattic/mcp-wordpress-remote@latest" ],
 			"env": {
 			    "NODE_TLS_REJECT_UNAUTHORIZED": "0",
-				"WP_API_URL": "https://example.test/",
+				"WP_API_URL": "https://example.test/wp-json/mcp/mcp-adapter-default-server",
 				"JWT_TOKEN": "{your_jwt-token-here}",
 			}
 		}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add to your MCP client configuration (e.g., Claude Desktop's `claude_desktop_con
       "command": "npx",
       "args": ["-y", "@automattic/mcp-wordpress-remote"],
       "env": {
-        "WP_API_URL": "https://your-wordpress-site.com"
+        "WP_API_URL": "https://your-wordpress-site.com/wp-json/mcp/mcp-adapter-default-server"
       }
     }
   }
@@ -58,7 +58,7 @@ You can add custom headers to all API requests using the `CUSTOM_HEADERS` enviro
       "command": "npx",
       "args": ["-y", "@automattic/mcp-wordpress-remote"],
       "env": {
-        "WP_API_URL": "https://your-wordpress-site.com",
+        "WP_API_URL": "https://your-wordpress-site.com/wp-json/mcp/mcp-adapter-default-server",
         "CUSTOM_HEADERS": "{\"X-MCP-API-Key\": \"*Ibo7tweixlbfuwaiufxgakjyefctwajcetb*\", \"X-Custom-Header\": \"value\"}"
       }
     }
@@ -75,7 +75,7 @@ You can add custom headers to all API requests using the `CUSTOM_HEADERS` enviro
       "command": "npx",
       "args": ["-y", "@automattic/mcp-wordpress-remote"],
       "env": {
-        "WP_API_URL": "https://your-wordpress-site.com",
+        "WP_API_URL": "https://your-wordpress-site.com/wp-json/mcp/mcp-adapter-default-server",
         "CUSTOM_HEADERS": "X-MCP-API-Key:IOskncfyes78U8on3q7ry43o487tybrc,X-Custom-Header:value"
       }
     }
@@ -87,7 +87,7 @@ You can add custom headers to all API requests using the `CUSTOM_HEADERS` enviro
 
 ```bash
 CUSTOM_HEADERS='{"X-MCP-API-Key": "wc_mcp_FaQduhQcW0mfVaZgP3yaaqDuXaZ3mw7j"}' \
-WP_API_URL="https://your-site.com" \
+WP_API_URL="https://your-site.com/wp-json/mcp/mcp-adapter-default-server" \
 npx @automattic/mcp-wordpress-remote
 ```
 
@@ -109,7 +109,11 @@ Custom headers are included in:
 
 ## WordPress MCP Plugin
 
-You need to install the [wordpress-mcp](https://github.com/WordPress/mcp-adapter) plugin on your WordPress website and enable MCP Functionality in Settings > MCP Settings.
+Install the [MCP Adapter](https://github.com/WordPress/mcp-adapter) plugin on your WordPress site. Once active, it registers a default MCP server at `/wp-json/mcp/mcp-adapter-default-server` — set `WP_API_URL` to that full URL (examples throughout this README show the pattern). To target a custom server id or namespace, pass the full URL of that server instead.
+
+### Legacy `wordpress-mcp` plugin
+
+Earlier versions of this proxy were designed for [`Automattic/wordpress-mcp`](https://github.com/Automattic/wordpress-mcp), which exposes its endpoint at `/wp-json/wp/v2/wpmcp`. That plugin is deprecated in favor of `mcp-adapter`, but existing installs continue to work — for backwards compatibility, a bare-domain `WP_API_URL` (e.g. `https://your-wordpress-site.com`) still resolves to the `wordpress-mcp` endpoint. New setups should install `mcp-adapter` and use the full URL shown above.
 
 ## Authentication Methods
 
@@ -126,7 +130,7 @@ OAuth 2.1 provides the most secure and user-friendly experience with full MCP Au
       "command": "npx",
       "args": ["-y", "@automattic/mcp-wordpress-remote"],
       "env": {
-        "WP_API_URL": "https://your-wordpress-site.com",
+        "WP_API_URL": "https://your-wordpress-site.com/wp-json/mcp/mcp-adapter-default-server",
         "OAUTH_ENABLED": "true"
       }
     }
@@ -163,7 +167,7 @@ For server-to-server authentication or when OAuth is not available.
       "command": "npx",
       "args": ["-y", "@automattic/mcp-wordpress-remote"],
       "env": {
-        "WP_API_URL": "https://your-wordpress-site.com",
+        "WP_API_URL": "https://your-wordpress-site.com/wp-json/mcp/mcp-adapter-default-server",
         "JWT_TOKEN": "your-jwt-token-here"
       }
     }
@@ -182,7 +186,7 @@ Uses WordPress username and application password for basic authentication.
       "command": "npx",
       "args": ["-y", "@automattic/mcp-wordpress-remote"],
       "env": {
-        "WP_API_URL": "https://your-wordpress-site.com",
+        "WP_API_URL": "https://your-wordpress-site.com/wp-json/mcp/mcp-adapter-default-server",
         "WP_API_USERNAME": "your-username",
         "WP_API_PASSWORD": "your-application-password",
         "OAUTH_ENABLED": "false"
@@ -210,7 +214,7 @@ To create an application password:
       "command": "npx",
       "args": ["-y", "@automattic/mcp-wordpress-remote"],
       "env": {
-        "WP_API_URL": "https://your-wordpress-site.com",
+        "WP_API_URL": "https://your-wordpress-site.com/wp-json/mcp/mcp-adapter-default-server",
         "OAUTH_CALLBACK_PORT": "7665",
         "OAUTH_HOST": "127.0.0.1",
         "WP_OAUTH_CLIENT_ID": "your-custom-client-id"
@@ -231,7 +235,7 @@ For WooCommerce-specific tools and reports:
       "command": "npx",
       "args": ["-y", "@automattic/mcp-wordpress-remote"],
       "env": {
-        "WP_API_URL": "https://your-wordpress-site.com",
+        "WP_API_URL": "https://your-wordpress-site.com/wp-json/mcp/mcp-adapter-default-server",
         "WOO_CUSTOMER_KEY": "ck_your-consumer-key",
         "WOO_CUSTOMER_SECRET": "cs_your-consumer-secret"
       }
@@ -244,7 +248,7 @@ For WooCommerce-specific tools and reports:
 
 | Variable                      | Description                                      | Default              | Required              |
 | ----------------------------- | ------------------------------------------------ | -------------------- | --------------------- |
-| `WP_API_URL`                  | WordPress site URL                               | -                    | ✅                    |
+| `WP_API_URL`                  | WordPress site URL including the MCP endpoint path (e.g. `…/wp-json/mcp/mcp-adapter-default-server`). A bare domain resolves to the deprecated `wordpress-mcp` endpoint for backwards compatibility. | - | ✅ |
 | `OAUTH_ENABLED`               | Enable OAuth authentication                      | `true`               | -                     |
 | `OAUTH_CALLBACK_PORT`         | OAuth callback port                              | `7665`               | -                     |
 | `OAUTH_HOST`                  | OAuth callback hostname                          | `127.0.0.1`          | -                     |
@@ -317,7 +321,7 @@ Configure your MCP client to use the local version:
       "command": "node",
       "args": ["/path/to/your/mcp-wordpress-remote/dist/proxy.js"],
       "env": {
-        "WP_API_URL": "https://your-wordpress-site.com"
+        "WP_API_URL": "https://your-wordpress-site.com/wp-json/mcp/mcp-adapter-default-server"
       }
     }
   }
@@ -403,9 +407,8 @@ If you see "waiting for other instance" messages, this is normal behavior.
 
 **API endpoint not found:**
 
-- Verify WordPress MCP plugin is installed and activated
-- Check plugin is enabled in WordPress admin
-- Confirm `WP_API_URL` is correct
+- Verify the [MCP Adapter](https://github.com/WordPress/mcp-adapter) plugin is installed and active
+- Confirm `WP_API_URL` points at the server route (e.g. `…/wp-json/mcp/mcp-adapter-default-server`)
 
 **Permission denied:**
 
@@ -469,7 +472,7 @@ Log levels:
 ## Requirements
 
 - **Node.js 22+** (required for fetch API support)
-- **WordPress site** with [wordpress-mcp](https://github.com/Automattic/wordpress-mcp) plugin
+- **WordPress site** with the [MCP Adapter](https://github.com/WordPress/mcp-adapter) plugin installed and active
 - **WordPress user account** with appropriate permissions
 
 ## License
@@ -484,7 +487,7 @@ Contributions welcome! This project is maintained by Automattic Inc.
 
 - **Issues:** [GitHub Issues](https://github.com/Automattic/mcp-wordpress-remote/issues)
 - **Documentation:** Check the troubleshooting section above
-- **WordPress MCP Plugin:** [Plugin Repository](https://github.com/Automattic/wordpress-mcp)
+- **WordPress MCP Plugin:** [WordPress/mcp-adapter](https://github.com/WordPress/mcp-adapter)
 
 ---
 


### PR DESCRIPTION
## Summary

- Document [`WordPress/mcp-adapter`](https://github.com/WordPress/mcp-adapter) as the primary plugin; point every `WP_API_URL` example at its default server endpoint (`/wp-json/mcp/mcp-adapter-default-server`).
- Replace the outdated "Settings > MCP Settings" instruction (that UI does not exist in `mcp-adapter`).
- Move `Automattic/wordpress-mcp` into a "Legacy" subsection explaining it is deprecated; a bare-domain `WP_API_URL` still resolves to its endpoint for backwards compatibility, so existing users are not broken.
- Clarify the `WP_API_URL` description in the env var table; update Requirements and Support links; cascade the URL updates into `Docs/troubleshooting.md`, `Docs/development.md`, `Docs/oauth-implicit-flow.md`.
- Adds an `AGENTS.md` parallel to `CLAUDE.md` for Codex (separate commit).

Supersedes #47 and #49, which each patched one symptom.

## Why

The README linked to `WordPress/mcp-adapter` while the instructions still assumed the deprecated `wordpress-mcp` plugin. Every example used a bare domain, which silently routes to the legacy `wpmcp` endpoint rather than the `mcp-adapter` default — so copy-paste setup against `mcp-adapter` failed for new users.

No code or test changes — the legacy bare-URL default is preserved as a backwards-compat path.

## Test plan

- [ ] README renders cleanly on GitHub (check the plugin section, migration subsection, env table cell, code fences).
- [ ] Every `WP_API_URL` example hits `…/wp-json/mcp/mcp-adapter-default-server` (no bare-domain examples remain except in the legacy note).
- [ ] Existing `wordpress-mcp` users with a bare `WP_API_URL` still work (no code change — verify by inspection of `src/lib/wordpress-api.ts` `constructApiUrl`).
- [ ] Close #47 and #49 with a comment pointing at this PR.