### PR TITLE
chore: release 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.2.21",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/mcp-wordpress-remote",
-      "version": "0.2.21",
+      "version": "0.3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
         "@tootallnate/quickjs-emscripten": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.2.21",
+  "version": "0.3.0",
   "description": "MCP WordPress Remote proxy server",
   "engines": {
     "node": ">=18.0.0"

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,7 +4,7 @@ import { selectCallbackPort } from './port-utils.js';
 import { logger } from './utils.js';
 
 // Version constant - update this manually when releasing new versions
-export const MCP_WORDPRESS_REMOTE_VERSION = '0.2.21';
+export const MCP_WORDPRESS_REMOTE_VERSION = '0.3.0';
 
 /**
  * Centralized configuration for MCP WordPress Remote

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -264,11 +264,12 @@ describe('Configuration Module', () => {
         JWT_TOKEN: 'test-token',
       });
 
-      const { getConfigHealthStatus } = await import('../../src/lib/config.js');
+      const { getConfigHealthStatus, MCP_WORDPRESS_REMOTE_VERSION } =
+        await import('../../src/lib/config.js');
       const status = getConfigHealthStatus();
 
       expect(status.status).toBe('healthy');
-      expect(status.version).toBe('0.2.19');
+      expect(status.version).toBe(MCP_WORDPRESS_REMOTE_VERSION);
       expect(status.uptime).toBeGreaterThan(0);
       expect(status.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
     });


### PR DESCRIPTION
## Summary

- Bump `package.json`, `package-lock.json`, and `src/lib/config.ts` `MCP_WORDPRESS_REMOTE_VERSION` from `0.2.21` to `0.3.0`.
- Fix the long-broken config health-status test (was hardcoded to `0.2.19`, failing since 0.2.20). It now reads the version constant directly so future bumps do not reintroduce the drift.

## Why

Minor bump because #51 added text/event-stream response support — a user-visible new capability.

Release contents since 0.2.21:
- #51 — feat: support text/event-stream responses from WordPress MCP endpoint
- #53 — fix: recover from expired session errors
- #52 — fix: token dir "wordpress-remote-undefined" suffix
- #54 — docs: rewrite README for mcp-adapter as primary plugin

## Test plan

- [x] Full unit + integration suite passes (175/175).
- [ ] Per CLAUDE.md pre-publish release gate: `npm ci && npm run build && npm pack`; install the tarball in a clean temp dir; verify `npx mcp-wordpress-remote --help`; smoke-test against a healthy WordPress endpoint (init + `tools/list`) and a broken endpoint (fallback init).
- [ ] Publish canary (`0.3.0-canary.1`) first, soak in real clients, then promote to `latest`.