### PR TITLE
ci: publish to npm on GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Check out the tagged commit
         uses: actions/checkout@v4
@@ -42,11 +43,9 @@ jobs:
         run: npm run build
 
       - name: Publish (canary dist-tag on prerelease, latest on stable)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
-            npm publish --access public --tag canary
+            npm publish --access public --provenance --tag canary
           else
-            npm publish --access public
+            npm publish --access public --provenance
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Publish to npm on release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the tagged commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify release tag matches package.json
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          EXPECTED_TAG="v${PKG_VERSION}"
+          if [ "${RELEASE_TAG}" != "${EXPECTED_TAG}" ]; then
+            echo "Release tag '${RELEASE_TAG}' does not match package.json version '${EXPECTED_TAG}'."
+            exit 1
+          fi
+
+      - name: Run tests
+        run: npx jest tests/ --no-coverage
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish (canary dist-tag on prerelease, latest on stable)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            npm publish --access public --tag canary
+          else
+            npm publish --access public
+          fi


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that publishes to npm when a GitHub release is published.

- Checks out the exact tagged commit (not `trunk` HEAD).
- Verifies the tag (`vX.Y.Z`) matches `package.json`.
- Runs tests and build.
- Publishes with dist-tag `canary` for prereleases and `latest` (npm default) for stable releases.

## Why

Matches the canary-first release gate in `CLAUDE.md`, removes the manual `npm publish` step, and guarantees the artifact comes from the tagged commit after tests and build pass.

## Prerequisites before the workflow can publish

- [ ] `NPM_TOKEN` repository secret added under Settings → Secrets and variables → Actions, with publish access to `@automattic/mcp-wordpress-remote`.

## Test plan

- [ ] Add the `NPM_TOKEN` secret.
- [ ] After merge, create a prerelease tag (e.g. `v0.3.0-canary.1`) via `gh release create v0.3.0-canary.1 --prerelease --target trunk --notes "canary soak"` and confirm the workflow publishes with the `canary` dist-tag (`npm view @automattic/mcp-wordpress-remote dist-tags`).
- [ ] After soaking, create `v0.3.0` (stable) and confirm it replaces `latest`.