### PR TITLE
ci: upgrade npm to 11+ for Trusted Publishing OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm to 11+ (required for Trusted Publishing OIDC)
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary

Install \`npm@latest\` globally before \`npm ci\` in the release workflow.

## Why

Node 22 bundles npm 10.9.x. That version supports OIDC provenance signing (Sigstore) but still uses bearer-token auth for the registry PUT. npm Trusted Publishing (OIDC-based authentication that exchanges the GitHub id-token for a short-lived publish credential) requires **npm 11.5+**.

Symptom with the old npm: the v0.3.0 release workflow built the tarball, signed the provenance, and logged it to Sigstore — then the registry PUT failed with \`404 Not Found\` because the bearer token was empty. npm obscures OIDC auth failures as 404.

With npm 11+, the CLI detects \`GITHUB_ACTIONS=true\` + \`id-token: write\`, exchanges OIDC for a publish credential automatically, and the PUT succeeds.

## After merge

Delete and recreate \`v0.3.0\` so the release workflow re-runs against this fixed commit.