### PR TITLE
ci: run npm@latest only for the publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,6 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Upgrade npm to 11+ (required for Trusted Publishing OIDC)
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: npm ci
 
@@ -46,9 +43,13 @@ jobs:
         run: npm run build
 
       - name: Publish (canary dist-tag on prerelease, latest on stable)
+        # Use npm@latest via npx because Node 22 bundles npm 10, but Trusted
+        # Publishing (OIDC token exchange for the registry PUT) needs npm 11.5+.
+        # Upgrading the global npm in-place can corrupt its own dependencies, so
+        # we scope the newer npm to just the publish step.
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
-            npm publish --access public --provenance --tag canary
+            npx -y npm@latest publish --access public --provenance --tag canary
           else
-            npm publish --access public --provenance
+            npx -y npm@latest publish --access public --provenance
           fi


### PR DESCRIPTION
## Summary

Replace \`npm install -g npm@latest\` with \`npx -y npm@latest publish\` scoped to the publish step only.

## Why

Upgrading the global npm in-place while npm is running triggers a known dependency-removal race inside npm itself — the v0.3.0 workflow run from PR #58 failed with \`MODULE_NOT_FOUND: Cannot find module 'promise-retry'\` coming from npm's own Arborist.

Trusted Publishing OIDC is only needed at publish time, so scoping npm 11+ to that single invocation (via \`npx\`) avoids the self-upgrade breakage entirely. \`npm ci\` and the build keep using the bundled npm 10.

## After merge

Delete and recreate \`v0.3.0\` so the workflow re-runs against this commit.