### PR TITLE
Fix WPCOM session refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/mcp-wordpress-remote",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
         "@tootallnate/quickjs-emscripten": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "MCP WordPress Remote proxy server",
   "engines": {
     "node": ">=18.0.0"

--- a/src/lib/wordpress-api.ts
+++ b/src/lib/wordpress-api.ts
@@ -37,8 +37,9 @@ let lastInitializeRequest: { requestData: any; useJsonRpc: boolean } | null = nu
 let sessionRefreshPromise: Promise<void> | null = null;
 
 const WP_MCP_ENDPOINT = '/wp/v2/wpmcp';
-const INVALID_SESSION_ERROR_CODE = -32602;
+const INVALID_SESSION_ERROR_CODES = new Set([-32602, -32005]);
 const INVALID_SESSION_ERROR_MESSAGE = 'Invalid or expired session';
+const SESSION_NOT_FOUND_ERROR_MESSAGE = 'Session not found';
 
 function validateEnvironment() {
   const validation = validateConfig();
@@ -253,9 +254,19 @@ function parseApiErrorResponse(error: APIError): any {
 
 function isInvalidSessionError(error: APIError): boolean {
   const errorResponse = parseApiErrorResponse(error);
+  const jsonRpcError =
+    errorResponse?.error && typeof errorResponse.error === 'object'
+      ? errorResponse.error
+      : errorResponse;
+  const code = typeof jsonRpcError?.code === 'number' ? jsonRpcError.code : null;
+  const message = typeof jsonRpcError?.message === 'string' ? jsonRpcError.message : '';
+
   return (
-    errorResponse?.code === INVALID_SESSION_ERROR_CODE &&
-    errorResponse?.message === INVALID_SESSION_ERROR_MESSAGE
+    code !== null &&
+    INVALID_SESSION_ERROR_CODES.has(code) &&
+    (message === INVALID_SESSION_ERROR_MESSAGE ||
+      message.includes(SESSION_NOT_FOUND_ERROR_MESSAGE) ||
+      message.includes(INVALID_SESSION_ERROR_MESSAGE))
   );
 }
 

--- a/tests/unit/wordpress-api.test.ts
+++ b/tests/unit/wordpress-api.test.ts
@@ -531,6 +531,81 @@ describe('WordPress API Module', () => {
         expect(nock.isDone()).toBe(true);
       });
 
+      it('should refresh the session for WPCOM session-not-found errors returned as HTTP JSON-RPC responses', async () => {
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://public-api.wordpress.com/wpcom/v2/mcp/v1',
+          JWT_TOKEN: 'test-token',
+        });
+
+        const initializeRequest = {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            clientInfo: {
+              name: 'test-client',
+              version: '1.0.0',
+            },
+            _proxy_request_id: 1,
+          },
+        };
+        const toolRequest = {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/call',
+          params: {
+            name: 'wpcom-mcp-account',
+            arguments: {
+              action: 'list',
+            },
+          },
+        };
+
+        const initHeaders: Array<string | undefined> = [];
+        let initCallCount = 0;
+
+        nock('https://public-api.wordpress.com')
+          .post('/wpcom/v2/mcp/v1', initializeRequest)
+          .twice()
+          .reply(function () {
+            const header = this.req.headers['mcp-session-id'];
+            initHeaders.push(Array.isArray(header) ? header[0] : (header as string | undefined));
+            initCallCount += 1;
+
+            return [
+              200,
+              createJsonRpcResult(1, { protocolVersion: '2025-06-18' }),
+              {
+                'Mcp-Session-Id': initCallCount === 1 ? 'session-1' : 'session-2',
+              },
+            ];
+          });
+
+        nock('https://public-api.wordpress.com')
+          .post('/wpcom/v2/mcp/v1', toolRequest)
+          .matchHeader('mcp-session-id', 'session-1')
+          .reply(
+            404,
+            createJsonRpcError(2, -32005, 'Session not found: Invalid or expired session')
+          );
+
+        nock('https://public-api.wordpress.com')
+          .post('/wpcom/v2/mcp/v1', toolRequest)
+          .matchHeader('mcp-session-id', 'session-2')
+          .reply(200, createJsonRpcResult(2, { content: [], structuredContent: {} }));
+
+        const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+
+        await wpRequest(initializeRequest, true);
+        await expect(wpRequest(toolRequest, true)).resolves.toEqual({
+          content: [],
+          structuredContent: {},
+        });
+
+        expect(initHeaders).toEqual([undefined, undefined]);
+        expect(nock.isDone()).toBe(true);
+      });
+
       it('should reuse a shared refresh when stale-session errors resolve out of order', async () => {
         restoreEnv = mockEnv({
           WP_API_URL: 'https://my-wp-site.com',


### PR DESCRIPTION
## Summary

- Treat WPCOM JSON-RPC `Session not found` responses as stale-session errors.
- Refresh the MCP session and retry the original request when WPCOM returns code `-32005` with the stale-session message.
- Add a regression test for the WPCOM HTTP JSON-RPC error shape.
- Bump the package version to `0.3.1`.

## Root Cause

WPCOM can return stale MCP sessions as HTTP JSON-RPC error responses with code `-32005` and a nested `error` object. The previous detector only matched the direct `-32602` `Invalid or expired session` shape, so those WPCOM responses did not trigger a refresh.

## Validation

- `npx jest tests/unit/ --no-coverage`
- `npm run build`