### PR TITLE
fix: use socks5h:// for synthesized SOCKS proxy URLs

### DIFF
--- a/src/lib/proxy-utils.ts
+++ b/src/lib/proxy-utils.ts
@@ -198,7 +198,7 @@ async function doInitializeProxy(): Promise<void> {
   if (macProxy?.socks) {
     const { host, port } = macProxy.socks;
     const bracketedHost = host.includes(':') ? `[${host}]` : host;
-    const socksUrl = `socks5://${bracketedHost}:${port}`;
+    const socksUrl = `socks5h://${bracketedHost}:${port}`;
     proxyConfig = { type: 'env', envProxy: { url: socksUrl, type: 'socks' } };
     logger.info(`System SOCKS proxy configured: ${sanitizeProxyUrl(socksUrl)}`, 'PROXY');
     return;
@@ -251,7 +251,7 @@ export async function getAgentForUrl(url: string): Promise<ProxyAgent | undefine
         // Parse "SOCKS host:port" or "SOCKS5 host:port" (case-insensitive)
         const socksMatch = directive.match(/SOCKS5?\s+(\S+):(\d+)/i);
         if (socksMatch) {
-          const proxyUrl = `socks5://${socksMatch[1]}:${socksMatch[2]}`;
+          const proxyUrl = `socks5h://${socksMatch[1]}:${socksMatch[2]}`;
           logger.debug(`PAC returned SOCKS proxy for ${url}: ${sanitizeProxyUrl(proxyUrl)}`, 'PROXY');
           return new SocksProxyAgent(proxyUrl);
         }


### PR DESCRIPTION
  ## Summary

  PAC `SOCKS host:port` directives and macOS-detected system SOCKS proxies were synthesized as `socks5://`, which makes `socks-proxy-agent` resolve destination hostnames **on the client side** and send the resulting IP in the SOCKS5 CONNECT. For dual-stack hosts the client may pick an IPv6 the proxy itself cannot route to, and the connection dies at the proxy with no fallback — surfacing as `FetchError: ... Socket closed` before any HTTP bytes flow.

  Switching the two synthesis sites to `socks5h://` moves DNS to the proxy, which is the only side that knows what its own network can actually reach.

  ## Reproduction

  Against `api.wpvip.com` (dual-stack: A `192.0.66.29`, AAAA `2a04:fa87:fffd::c000:421d`) through an `ssh -D 8080` tunnel whose remote end is IPv4-only:

  [DEBUG] [PROXY] PAC returned SOCKS proxy for https://api.wpvip.com/mcp: socks5://127.0.0.1:8080
  [WARN]  [OAUTH] 401 response discovery method failed:
          FetchError: request to https://api.wpvip.com/mcp failed, reason: Socket closed

  Verified with curl:

  ```bash
  # breaks (local DNS picks IPv6, proxy can't route)
  curl --proxy socks5://127.0.0.1:8080  https://api.wpvip.com/mcp

  # works (proxy resolves, picks IPv4 it can reach)
  curl --proxy socks5h://127.0.0.1:8080 https://api.wpvip.com/mcp
```

##  Why `socks5h://`

  `socks5h://` sends the hostname literal over `SOCKS5` (address type 0x03) instead of a resolved IP. Address selection then happens in the proxy's network context, where it belongs.

  This matches PAC semantics — SOCKS host:port directives have always implied remote DNS — and Chrome's hardcoded behavior for SOCKS5 proxies:

  ▎ In Chrome when a proxy's scheme is set to SOCKSv5, name resolution is always done proxy side (even though the protocol allows for client side as well). In Firefox client side vs proxy side name 
  ▎ resolution can be configured with network.proxy.socks_remote_dns; Chrome has no equivalent option and will always use proxy side resolution.

  — https://chromium.googlesource.com/chromium/src/+/HEAD/net/docs/proxy.md#SOCKSv5-proxy-scheme

##  Scope
  
  `detectEnvProxy()` is intentionally left untouched — explicit `SOCKS_PROXY` / `ALL_PROXY` values from the operator are passed through verbatim, preserving their scheme choice.

