### PR TITLE
fix: preserve Error message and stack in log output

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,6 +33,42 @@ if (process.env.LOG_FILE) {
 }
 
 /**
+ * Format a single log argument for output.
+ *
+ * Error instances are expanded explicitly because JSON.stringify drops their
+ * most useful fields: `message` and `stack` are non-enumerable, so a plain
+ * Error serializes to `{}`. Custom errors such as APIError keep their extra
+ * own properties (statusCode, endpoint, response) which are merged in.
+ *
+ * @param arg - The argument to format
+ * @returns A string representation suitable for the log line
+ */
+function formatLogArg(arg: any): string {
+  if (arg instanceof Error) {
+    const errorInfo: Record<string, unknown> = {
+      name: arg.name,
+      message: arg.message,
+      stack: arg.stack,
+    };
+
+    // Merge in any extra own enumerable properties (e.g. statusCode, endpoint).
+    for (const key of Object.keys(arg)) {
+      if (!(key in errorInfo)) {
+        errorInfo[key] = (arg as any)[key];
+      }
+    }
+
+    return JSON.stringify(errorInfo, null, 2);
+  }
+
+  if (typeof arg === 'object' && arg !== null) {
+    return JSON.stringify(arg, null, 2);
+  }
+
+  return String(arg);
+}
+
+/**
  * Enhanced logging function with levels and categories
  *
  * @param message - The message to log
@@ -53,10 +89,7 @@ export function log(
 
   const timestamp = new Date().toISOString();
   const levelName = LogLevel[level];
-  const formattedArgs =
-    args.length > 0
-      ? args.map(arg => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : arg)).join(' ')
-      : '';
+  const formattedArgs = args.length > 0 ? args.map(formatLogArg).join(' ') : '';
 
   const logMessage = `${timestamp} [${levelName}] [${category}] ${message}${formattedArgs ? '\n' + formattedArgs : ''}\n`;
 

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -93,6 +93,53 @@ describe('Utils Module', () => {
       );
     });
 
+    it('should include Error message and stack in log output', async () => {
+      restoreEnv = mockEnv({
+        LOG_TO_STDERR: 'true',
+        LOG_LEVEL: '3', // DEBUG level to see the message
+      });
+
+      const { log, LogLevel } = await import('../../src/lib/utils.js');
+
+      log('Init failed', LogLevel.ERROR, 'INIT', new Error('connection refused'));
+
+      // Plain JSON.stringify(new Error()) returns "{}" — the message must survive.
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringMatching(/"message":\s*"connection refused"/)
+      );
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringMatching(/"name":\s*"Error"/)
+      );
+      expect(process.stderr.write).toHaveBeenCalledWith(expect.stringMatching(/"stack":/));
+    });
+
+    it('should include custom error properties like statusCode and endpoint', async () => {
+      restoreEnv = mockEnv({
+        LOG_TO_STDERR: 'true',
+        LOG_LEVEL: '3',
+      });
+
+      const { log, LogLevel } = await import('../../src/lib/utils.js');
+
+      // Simulate an APIError shape: Error subclass with extra own properties.
+      const apiError = new Error('Request failed with status 404');
+      apiError.name = 'APIError';
+      (apiError as any).statusCode = 404;
+      (apiError as any).endpoint = 'https://example.com/?rest_route=/wp/v2/wpmcp';
+
+      log('WordPress request failed', LogLevel.ERROR, 'API', apiError);
+
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringMatching(/"message":\s*"Request failed with status 404"/)
+      );
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringMatching(/"statusCode":\s*404/)
+      );
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringMatching(/"endpoint":\s*"https:\/\/example\.com\/\?rest_route=\/wp\/v2\/wpmcp"/)
+      );
+    });
+
     it('should respect log level filtering', async () => {
       restoreEnv = mockEnv({
         LOG_TO_STDERR: 'true',


### PR DESCRIPTION
## What

`log()` serialized extra arguments with `JSON.stringify`. On `Error` instances, `message` and `stack` are non-enumerable, so a plain `Error` serialized to `{}`. The init failure logged in `proxy.ts` and the transport failures in `transport-detection.ts` recorded their real cause as an empty object — leaving no useful detail in the logs.

Added `formatLogArg` in `src/lib/utils.ts`. It expands `Error` instances into `name`, `message`, `stack`, plus any extra own properties (`APIError` keeps `statusCode`, `endpoint`, `response`). Non-error objects keep the previous `JSON.stringify` behavior, so the blast radius is limited to error arguments.

## Why

Closes the open follow-up in #48: the connection problem was a config/URL issue, but the reporter noted "the logging is still lacking" — when initialization failed, the logs showed `{}` instead of the actual error. Now the real message, stack, and HTTP status/endpoint reach the log file.

## Testing

- Two new cases in `tests/unit/utils.test.ts`: a plain `Error` (message + name + stack survive) and an `APIError`-shaped error (`statusCode` + `endpoint` survive).
- Full unit suite: 174 pass.
- Build: success.

## Out of scope

The client-facing generic message (`Cannot process prompts/list: WordPress connection failed during initialization` in `request-handler-factory.ts`) is unchanged. Threading the cause into that message would change `resolveInit`'s signature and the `_init` shape across files. Can follow up if wanted.