### PR TITLE
fix: surface connection failures and bound the init handshake (#61)

### DIFF
--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -43,22 +43,63 @@ You can then update your MCP server configuration to use the full path for `npx`
 
 # Local development environments and SSL
 
-If you use a local development environment with a self-signed SSL certificate, you may [encounter issues with the MCP server connecting to your WordPress site](https://stackoverflow.com/questions/79669669/how-can-i-get-claude-code-to-trust-my-local-mcp-servers-self-signed-cert).
+If your WordPress site uses a certificate signed by a CA that your operating system trusts but Node.js does not — for example `mkcert` (DDEV, Laravel Valet), a corporate CA, or a VPN — the proxy will fail to connect. Node ships its own bundled CA list and ignores the OS trust store by default, so the certificate is rejected even though `curl` and your browser accept it.
 
-You can work around this by setting the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable to `0` in your MCP server configuration. This will disable SSL certificate validation, allowing the MCP server to connect to your local WordPress site without issues.
+Symptoms: the MCP client shows "Connection Failed", and the proxy logs an error such as `UNABLE_TO_VERIFY_LEAF_SIGNATURE` or `SELF_SIGNED_CERT_IN_CHAIN` on stderr (error-level logs are always written to stderr).
 
-```php
-{
-	"mcpServers": {
-		"wordpress": {
-			"command": "/Users/username/.nvm/versions/node/v22.16.0/bin/npx",
-			"args": [ "-y", "@automattic/mcp-wordpress-remote@latest" ],
-			"env": {
-			    "NODE_TLS_REJECT_UNAUTHORIZED": "0",
-				"WP_API_URL": "https://example.test/wp-json/mcp/mcp-adapter-default-server",
-				"JWT_TOKEN": "{your_jwt-token-here}",
-			}
-		}
-	}
+Fix it by making Node trust the CA. In order of preference:
+
+1. **Point Node at the CA file** with `NODE_EXTRA_CA_CERTS`. For `mkcert`, find the path with `mkcert -CAROOT` (the file is `rootCA.pem` inside that directory). This keeps certificate validation enabled.
+
+   ```json
+   {
+   	"mcpServers": {
+   		"wordpress": {
+   			"command": "/Users/username/.nvm/versions/node/v22.16.0/bin/npx",
+   			"args": [ "-y", "@automattic/mcp-wordpress-remote@latest" ],
+   			"env": {
+   				"NODE_EXTRA_CA_CERTS": "/Users/username/Library/Application Support/mkcert/rootCA.pem",
+   				"WP_API_URL": "https://example.test/wp-json/mcp/mcp-adapter-default-server",
+   				"JWT_TOKEN": "{your_jwt-token-here}"
+   			}
+   		}
+   	}
+   }
+   ```
+
+2. **Trust the OS certificate store** with `NODE_USE_SYSTEM_CA=1` (Node 22.15+, 23.9+, or 24+). This works for any CA already installed in the OS, with no file path to manage.
+
+   ```json
+   "env": {
+   	"NODE_USE_SYSTEM_CA": "1",
+   	"WP_API_URL": "https://example.test/wp-json/mcp/mcp-adapter-default-server",
+   	"JWT_TOKEN": "{your_jwt-token-here}"
+   }
+   ```
+
+3. **Insecure last resort:** set `NODE_TLS_REJECT_UNAUTHORIZED` to `0`. This disables all certificate validation and exposes the connection to man-in-the-middle attacks. Use it only for throwaway local testing, never against a real or remote site.
+
+   ```json
+   "env": {
+   	"NODE_TLS_REJECT_UNAUTHORIZED": "0",
+   	"WP_API_URL": "https://example.test/wp-json/mcp/mcp-adapter-default-server",
+   	"JWT_TOKEN": "{your_jwt-token-here}"
+   }
+   ```
+
+After changing the environment, restart your MCP client so the proxy is relaunched with the new variables.
+
+# Connection hangs at startup
+
+If the MCP client shows the server "connecting" for a long time and then times out, the proxy is likely waiting on an upstream that never responds — a stalled TLS handshake, a blackholed route, or a dead proxy. The proxy bounds this wait: the `initialize` handshake fails after `WP_API_INIT_TIMEOUT_MS` (default 25 seconds) and logs the reason to stderr, rather than hanging until the operating system's TCP timeout.
+
+If your network is slow and legitimate requests need longer, raise the limits:
+
+```json
+"env": {
+	"WP_API_INIT_TIMEOUT_MS": "40000",
+	"WP_API_TIMEOUT_MS": "180000"
 }
 ```
+
+`WP_API_INIT_TIMEOUT_MS` bounds the startup handshake; `WP_API_TIMEOUT_MS` bounds individual tool calls.

--- a/README.md
+++ b/README.md
@@ -266,6 +266,12 @@ For WooCommerce-specific tools and reports:
 | `WP_MCP_CONFIG_DIR`           | Config directory override                        | `~/.mcp-auth`        | -                     |
 | `LOG_FILE`                    | Log file path                                    | -                    | -                     |
 | `LOG_LEVEL`                   | Log level (0-3)                                  | `2`                  | -                     |
+| `LOG_TO_STDERR`               | Mirror all log levels to stderr (errors always are) | `false`           | -                     |
+| `WP_API_TIMEOUT_MS`           | Request timeout for tool calls (ms)              | `120000`             | -                     |
+| `WP_API_INIT_TIMEOUT_MS`      | Timeout for the initialize handshake (ms)        | `25000`              | -                     |
+| **TLS / Certificates**        |                                                  |                      |                       |
+| `NODE_EXTRA_CA_CERTS`         | Path to an extra CA file to trust (mkcert/corporate CA) | -             | -                     |
+| `NODE_USE_SYSTEM_CA`          | Trust the OS certificate store (Node 22.15+)     | -                    | -                     |
 | **Legacy Authentication**     |                                                  |                      |                       |
 | `JWT_TOKEN`                   | JWT token for authentication                     | -                    | -                     |
 | `WP_API_USERNAME`             | WordPress username (legacy)                      | -                    | -                     |

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -7,6 +7,22 @@ import { logger } from './utils.js';
 export const MCP_WORDPRESS_REMOTE_VERSION = '0.3.0';
 
 /**
+ * Parse a positive integer from an environment variable, falling back to a
+ * default when unset, non-numeric, or not greater than zero.
+ *
+ * @param value        - Raw environment variable value.
+ * @param defaultValue - Fallback when the value is missing or invalid.
+ * @returns A positive integer.
+ */
+function parsePositiveIntEnv(value: string | undefined, defaultValue: number): number {
+  if (!value) {
+    return defaultValue;
+  }
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+}
+
+/**
  * Centralized configuration for MCP WordPress Remote
  * All default values are defined here and can be overridden via environment variables
  */
@@ -45,6 +61,15 @@ export const CONFIG = {
   // Timeout Configuration (in milliseconds)
   OAUTH_TIMEOUT: 30000, // 30 seconds
   LOCK_TIMEOUT: 300000, // 5 minutes
+
+  // WordPress request timeouts. Native fetch has no default timeout, so a
+  // stalled upstream (TLS handshake hang, blackholed route, dead proxy) would
+  // otherwise hang until the OS TCP timeout (~60s+). These bound the wait so
+  // the failure surfaces quickly with a clear error instead of silently.
+  // The initialize handshake should be fast and is what the MCP client waits
+  // on at startup, so it gets a tighter budget than regular tool calls.
+  WP_API_TIMEOUT: parsePositiveIntEnv(process.env.WP_API_TIMEOUT_MS, 120000), // 2 minutes
+  WP_API_INIT_TIMEOUT: parsePositiveIntEnv(process.env.WP_API_INIT_TIMEOUT_MS, 25000), // 25 seconds
 
   // Directory Configuration
   WP_MCP_CONFIG_DIR: process.env.WP_MCP_CONFIG_DIR || path.join(os.homedir(), '.mcp-auth'),
@@ -108,6 +133,12 @@ export const getConfig = () => ({
 
   /** Lock operation timeout in milliseconds */
   lockTimeout: CONFIG.LOCK_TIMEOUT,
+
+  /** WordPress request timeout in milliseconds (tool calls and non-init requests) */
+  wpApiTimeout: CONFIG.WP_API_TIMEOUT,
+
+  /** WordPress initialize handshake timeout in milliseconds */
+  wpApiInitTimeout: CONFIG.WP_API_INIT_TIMEOUT,
 
   /** Configuration directory path */
   configDir: CONFIG.WP_MCP_CONFIG_DIR,

--- a/src/lib/error-utils.ts
+++ b/src/lib/error-utils.ts
@@ -229,24 +229,54 @@ function buildApiErrorData(error: APIError): Record<string, unknown> {
 }
 
 /**
+ * The original WordPress JSON-RPC error, if this APIError wraps one.
+ *
+ * When WordPress returns a JSON-RPC error envelope, wpRequest stores that
+ * `{ code, message, data }` object as the APIError's `response`. We forward it
+ * verbatim so the proxy is transparent — the client sees WordPress's own error
+ * code, not a flattened internal error.
+ */
+function forwardedJsonRpcError(
+  error: APIError
+): { code: number; message?: string; data?: unknown } | null {
+  const response = error.response;
+  if (response && typeof response === 'object' && typeof (response as any).code === 'number') {
+    return response as { code: number; message?: string; data?: unknown };
+  }
+  return null;
+}
+
+/**
+ * Derive the MCP error code, message, and data for an APIError, covering all
+ * three failure sources:
+ *   - a WordPress JSON-RPC error  -> forward its original code, message, data
+ *   - an HTTP-status error        -> map the status, attach status/endpoint/body
+ *   - a below-HTTP failure (code 0: timeout/DNS/refused/TLS) -> map + code + hint
+ */
+function mcpErrorParts(error: APIError): { code: number; message: string; data?: unknown } {
+  const wpError = forwardedJsonRpcError(error);
+  if (wpError) {
+    return { code: wpError.code, message: wpError.message ?? error.message, data: wpError.data };
+  }
+  return { code: deriveMcpErrorCode(error), message: error.message, data: buildApiErrorData(error) };
+}
+
+/**
  * Converts an APIError to MCP error response format (used as a tool result on
  * the simple transport, where errors are returned rather than thrown).
  */
 export function convertAPIErrorToMcpError(error: APIError) {
-  return {
-    error: {
-      code: deriveMcpErrorCode(error),
-      message: error.message,
-      data: buildApiErrorData(error),
-    },
-  };
+  return { error: mcpErrorParts(error) };
 }
 
 /**
- * Convert an APIError into a thrown McpError, preserving the network code and
- * hint in `data`. Use for below-HTTP failures (timeout, DNS, refused, TLS) so
- * a JSON-RPC client sees the real cause instead of a bare internal error.
+ * Convert an APIError into a thrown McpError. Forwards a WordPress JSON-RPC
+ * error's original code/data, maps HTTP-status errors to a sensible MCP code,
+ * and surfaces below-HTTP failures (timeout, DNS, refused, TLS) with their code
+ * and hint — so a JSON-RPC client always sees the real cause, never a bare
+ * internal error.
  */
 export function apiErrorToMcpError(error: APIError): McpError {
-  return new McpError(deriveMcpErrorCode(error), error.message, buildApiErrorData(error));
+  const { code, message, data } = mcpErrorParts(error);
+  return new McpError(code, message, data);
 }

--- a/src/lib/error-utils.ts
+++ b/src/lib/error-utils.ts
@@ -4,7 +4,11 @@
  * Provides functions for converting API errors to MCP-compliant error formats
  */
 
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
 import { APIError } from './oauth-types.js';
+
+/** MCP JSON-RPC error code for a request timeout (per mapHttpStatusToMcpCode). */
+const MCP_TIMEOUT_ERROR_CODE = -32001;
 
 /**
  * Structured description of a connection-level failure (TLS, DNS, refused, etc.).
@@ -42,6 +46,27 @@ const CA_TRUST_HINT =
   'NODE_TLS_REJECT_UNAUTHORIZED=0 disables verification entirely.';
 
 /**
+ * Network error codes that mean "the request did not complete in time". A
+ * stalled upstream can surface any of these: our own AbortSignal.timeout
+ * normalizes to ETIMEDOUT, while undici's own connect/headers deadlines fire
+ * first with their own codes.
+ */
+const TIMEOUT_ERROR_CODES = new Set([
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+]);
+
+/**
+ * Whether a network error code represents a timeout. Used to decide that a
+ * failure is terminal (no transport fallback) and to map it to the MCP
+ * timeout error code.
+ */
+export function isTimeoutCode(code?: string): boolean {
+  return code != null && TIMEOUT_ERROR_CODES.has(code);
+}
+
+/**
  * Walk the `cause` chain of an error and return the first string `code` found.
  *
  * Node's `fetch` (undici) wraps the real network/TLS error as a `TypeError`
@@ -60,6 +85,26 @@ export function extractNetworkErrorCode(error: unknown): string | undefined {
 }
 
 /**
+ * Walk the `cause` chain and return the deepest (most specific) error message.
+ *
+ * undici reports TLS/network failures as a top-level `TypeError: fetch failed`
+ * whose `cause` carries the real detail (e.g. "unable to verify the first
+ * certificate"). Preferring the leaf keeps that detail instead of collapsing
+ * to the generic wrapper text.
+ */
+export function extractNetworkErrorMessage(error: unknown): string {
+  let current: any = error;
+  let message = error instanceof Error ? error.message : String(error);
+  for (let depth = 0; current && depth < 5; depth++) {
+    if (current instanceof Error && current.message) {
+      message = current.message;
+    }
+    current = current.cause;
+  }
+  return message;
+}
+
+/**
  * Return an actionable hint for a known connection error code, or undefined.
  */
 export function getConnectionErrorHint(code?: string): string | undefined {
@@ -71,6 +116,10 @@ export function getConnectionErrorHint(code?: string): string | undefined {
     return CA_TRUST_HINT;
   }
 
+  if (isTimeoutCode(code)) {
+    return 'The connection timed out. Check network, firewall, or proxy settings, or raise WP_API_TIMEOUT_MS / WP_API_INIT_TIMEOUT_MS.';
+  }
+
   switch (code) {
     case 'CERT_HAS_EXPIRED':
       return 'The server certificate has expired. Renew it on the WordPress host.';
@@ -80,9 +129,6 @@ export function getConnectionErrorHint(code?: string): string | undefined {
       return 'The connection was refused. Check that WP_API_URL points to a running server and the right port.';
     case 'ENOTFOUND':
       return 'The host could not be resolved (DNS). Check WP_API_URL for typos.';
-    case 'ETIMEDOUT':
-    case 'UND_ERR_CONNECT_TIMEOUT':
-      return 'The connection timed out. Check network, firewall, or proxy settings.';
     default:
       return undefined;
   }
@@ -150,18 +196,57 @@ export function mapHttpStatusToMcpCode(statusCode: number): number {
 }
 
 /**
- * Converts an APIError to MCP error response format
+ * Pick the MCP error code for an APIError. Timeout-class network failures
+ * (statusCode 0 with a timeout code) map to the timeout code rather than the
+ * generic internal error that statusCode 0 would otherwise produce.
+ */
+function deriveMcpErrorCode(error: APIError): number {
+  if (isTimeoutCode(error.code)) {
+    return MCP_TIMEOUT_ERROR_CODE;
+  }
+  return mapHttpStatusToMcpCode(error.statusCode);
+}
+
+/**
+ * Build the `data` payload for an APIError, including the underlying network
+ * code and an actionable hint when available, so the client can tell a timeout
+ * or TLS failure apart from a generic internal error.
+ */
+function buildApiErrorData(error: APIError): Record<string, unknown> {
+  const data: Record<string, unknown> = {
+    statusCode: error.statusCode,
+    endpoint: error.endpoint,
+    response: error.response,
+  };
+  if (error.code) {
+    data.code = error.code;
+  }
+  const hint = getConnectionErrorHint(error.code);
+  if (hint) {
+    data.hint = hint;
+  }
+  return data;
+}
+
+/**
+ * Converts an APIError to MCP error response format (used as a tool result on
+ * the simple transport, where errors are returned rather than thrown).
  */
 export function convertAPIErrorToMcpError(error: APIError) {
   return {
     error: {
-      code: mapHttpStatusToMcpCode(error.statusCode),
+      code: deriveMcpErrorCode(error),
       message: error.message,
-      data: {
-        statusCode: error.statusCode,
-        endpoint: error.endpoint,
-        response: error.response,
-      },
+      data: buildApiErrorData(error),
     },
   };
+}
+
+/**
+ * Convert an APIError into a thrown McpError, preserving the network code and
+ * hint in `data`. Use for below-HTTP failures (timeout, DNS, refused, TLS) so
+ * a JSON-RPC client sees the real cause instead of a bare internal error.
+ */
+export function apiErrorToMcpError(error: APIError): McpError {
+  return new McpError(deriveMcpErrorCode(error), error.message, buildApiErrorData(error));
 }

--- a/src/lib/error-utils.ts
+++ b/src/lib/error-utils.ts
@@ -7,6 +7,97 @@
 import { APIError } from './oauth-types.js';
 
 /**
+ * Structured description of a connection-level failure (TLS, DNS, refused, etc.).
+ * Used to surface the underlying cause to logs and to the MCP client instead of
+ * swallowing it behind a generic "connection failed" message.
+ */
+export interface ConnectionErrorInfo {
+  /** The underlying Node error code, e.g. "UNABLE_TO_VERIFY_LEAF_SIGNATURE". */
+  code?: string;
+  /** Human-readable error message. */
+  message: string;
+  /** Actionable hint for resolving the failure, when the code is recognized. */
+  hint?: string;
+}
+
+/**
+ * Node/OpenSSL error codes that mean "the certificate chain is valid but its
+ * root is not in Node's trust store" — the mkcert / DDEV / corporate-CA case.
+ */
+const CA_TRUST_ERROR_CODES = new Set([
+  'UNABLE_TO_GET_ISSUER_CERT',
+  'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'CERT_UNTRUSTED',
+]);
+
+const CA_TRUST_HINT =
+  'The server certificate was not trusted by Node.js. If the site uses a ' +
+  'locally-trusted or corporate CA (mkcert, DDEV, Laravel Valet, a VPN), make ' +
+  'Node trust it: set NODE_EXTRA_CA_CERTS to the CA file (e.g. the output of ' +
+  '`mkcert -CAROOT` plus rootCA.pem), or on Node 22.15+ set NODE_USE_SYSTEM_CA=1 ' +
+  'to trust the OS certificate store. As an insecure last resort, ' +
+  'NODE_TLS_REJECT_UNAUTHORIZED=0 disables verification entirely.';
+
+/**
+ * Walk the `cause` chain of an error and return the first string `code` found.
+ *
+ * Node's `fetch` (undici) wraps the real network/TLS error as a `TypeError`
+ * with the actual error in `.cause`, so the useful code is rarely on the
+ * top-level error.
+ */
+export function extractNetworkErrorCode(error: unknown): string | undefined {
+  let current: any = error;
+  for (let depth = 0; current && depth < 5; depth++) {
+    if (typeof current.code === 'string') {
+      return current.code;
+    }
+    current = current.cause;
+  }
+  return undefined;
+}
+
+/**
+ * Return an actionable hint for a known connection error code, or undefined.
+ */
+export function getConnectionErrorHint(code?: string): string | undefined {
+  if (!code) {
+    return undefined;
+  }
+
+  if (CA_TRUST_ERROR_CODES.has(code)) {
+    return CA_TRUST_HINT;
+  }
+
+  switch (code) {
+    case 'CERT_HAS_EXPIRED':
+      return 'The server certificate has expired. Renew it on the WordPress host.';
+    case 'ERR_TLS_CERT_ALTNAME_INVALID':
+      return 'The server certificate does not match the hostname in WP_API_URL. Check for a host/SAN mismatch.';
+    case 'ECONNREFUSED':
+      return 'The connection was refused. Check that WP_API_URL points to a running server and the right port.';
+    case 'ENOTFOUND':
+      return 'The host could not be resolved (DNS). Check WP_API_URL for typos.';
+    case 'ETIMEDOUT':
+    case 'UND_ERR_CONNECT_TIMEOUT':
+      return 'The connection timed out. Check network, firewall, or proxy settings.';
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Describe a connection-level error: its code, message, and an actionable hint.
+ */
+export function describeConnectionError(error: unknown): ConnectionErrorInfo {
+  const code = extractNetworkErrorCode(error);
+  const message = error instanceof Error ? error.message : String(error);
+  return { code, message, hint: getConnectionErrorHint(code) };
+}
+
+/**
  * Maps HTTP status codes to MCP JSON-RPC error codes
  * Based on JSON-RPC 2.0 specification and MCP best practices
  */

--- a/src/lib/oauth-types.ts
+++ b/src/lib/oauth-types.ts
@@ -134,13 +134,16 @@ export class APIError extends Error {
   public readonly statusCode: number;
   public readonly endpoint: string;
   public readonly response?: any;
+  /** Underlying network/TLS error code (e.g. "UNABLE_TO_VERIFY_LEAF_SIGNATURE"), when the failure was below the HTTP layer. */
+  public readonly code?: string;
 
-  constructor(message: string, statusCode: number, endpoint: string, response?: any) {
+  constructor(message: string, statusCode: number, endpoint: string, response?: any, code?: string) {
     super(message);
     this.name = 'APIError';
     this.statusCode = statusCode;
     this.endpoint = endpoint;
     this.response = response;
+    this.code = code;
 
     // Ensure proper prototype chain
     Object.setPrototypeOf(this, APIError.prototype);

--- a/src/lib/request-handler-factory.ts
+++ b/src/lib/request-handler-factory.ts
@@ -4,6 +4,7 @@
  * Creates standardized request handlers to eliminate repetitive code
  */
 
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { logger } from './utils.js';
 import { wpRequest } from './wordpress-api.js';
 import { isAPIError } from './oauth-types.js';
@@ -31,7 +32,19 @@ export function createRequestHandler(config: HandlerConfig, context: SessionCont
     const init = await waitForInit(context);
     if (!init.ready) {
       const cause = init.reason === 'timeout' ? 'timed out waiting for' : 'failed during';
-      throw new Error(`Cannot process ${config.method}: WordPress connection ${cause} initialization`);
+      const message = `Cannot process ${config.method}: WordPress connection ${cause} initialization`;
+      // Surface the underlying cause in the JSON-RPC error `data` so the client
+      // can show why initialization failed (TLS, DNS, refused) instead of a
+      // bare internal error.
+      const data: Record<string, unknown> = { reason: init.reason };
+      if (init.reason === 'failed' && init.error) {
+        data.code = init.error.code;
+        data.detail = init.error.message;
+        if (init.error.hint) {
+          data.hint = init.error.hint;
+        }
+      }
+      throw new McpError(ErrorCode.InternalError, message, data);
     }
 
     // Map request parameters to WordPress format

--- a/src/lib/request-handler-factory.ts
+++ b/src/lib/request-handler-factory.ts
@@ -8,7 +8,7 @@ import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { logger } from './utils.js';
 import { wpRequest } from './wordpress-api.js';
 import { isAPIError } from './oauth-types.js';
-import { convertAPIErrorToMcpError } from './error-utils.js';
+import { convertAPIErrorToMcpError, apiErrorToMcpError } from './error-utils.js';
 import { prepareRequest, waitForInit, SessionContext } from './session-utils.js';
 import { WPRequestParams } from './mcp-types.js';
 
@@ -112,18 +112,35 @@ export function createWrappedHandler(config: HandlerConfig, context: SessionCont
         requestId: request.id,
       });
       
-      // Only convert APIError to MCP error format for simple transport
-      // JSON-RPC transport already returns properly formatted JSON-RPC errors
-      if (isAPIError(error) && context.transportType === 'simple') {
-        logger.debug(`Converting APIError to MCP error format for ${config.name} (simple transport)`, 'MCP', {
-          statusCode: error.statusCode,
-          endpoint: error.endpoint,
-          message: error.message,
-        });
-        return convertAPIErrorToMcpError(error);
+      if (isAPIError(error)) {
+        // Simple transport returns errors as a tool result. convertAPIErrorToMcpError
+        // now carries the network code and hint, so a timeout/TLS failure is
+        // distinguishable here too.
+        if (context.transportType === 'simple') {
+          logger.debug(`Converting APIError to MCP error format for ${config.name} (simple transport)`, 'MCP', {
+            statusCode: error.statusCode,
+            endpoint: error.endpoint,
+            message: error.message,
+          });
+          return convertAPIErrorToMcpError(error);
+        }
+
+        // JSON-RPC transport: WordPress JSON-RPC errors (statusCode != 0) are
+        // already well-formed and flow to the SDK unchanged. Below-HTTP failures
+        // (timeout, DNS, refused, TLS) carry statusCode 0 and are NOT WordPress
+        // JSON-RPC errors, so surface the real code and hint instead of a bare
+        // -32603 internal error.
+        if (error.statusCode === 0) {
+          logger.debug(`Converting network APIError to McpError for ${config.name}`, 'MCP', {
+            code: error.code,
+            endpoint: error.endpoint,
+            message: error.message,
+          });
+          throw apiErrorToMcpError(error);
+        }
       }
-      
-      // For JSON-RPC transport or non-API errors, re-throw (MCP SDK will handle)
+
+      // For JSON-RPC WordPress errors or non-API errors, re-throw (MCP SDK will handle)
       throw error;
     }
   };

--- a/src/lib/request-handler-factory.ts
+++ b/src/lib/request-handler-factory.ts
@@ -113,9 +113,7 @@ export function createWrappedHandler(config: HandlerConfig, context: SessionCont
       });
       
       if (isAPIError(error)) {
-        // Simple transport returns errors as a tool result. convertAPIErrorToMcpError
-        // now carries the network code and hint, so a timeout/TLS failure is
-        // distinguishable here too.
+        // Simple transport returns errors as a tool result.
         if (context.transportType === 'simple') {
           logger.debug(`Converting APIError to MCP error format for ${config.name} (simple transport)`, 'MCP', {
             statusCode: error.statusCode,
@@ -125,22 +123,21 @@ export function createWrappedHandler(config: HandlerConfig, context: SessionCont
           return convertAPIErrorToMcpError(error);
         }
 
-        // JSON-RPC transport: WordPress JSON-RPC errors (statusCode != 0) are
-        // already well-formed and flow to the SDK unchanged. Below-HTTP failures
-        // (timeout, DNS, refused, TLS) carry statusCode 0 and are NOT WordPress
-        // JSON-RPC errors, so surface the real code and hint instead of a bare
-        // -32603 internal error.
-        if (error.statusCode === 0) {
-          logger.debug(`Converting network APIError to McpError for ${config.name}`, 'MCP', {
-            code: error.code,
-            endpoint: error.endpoint,
-            message: error.message,
-          });
-          throw apiErrorToMcpError(error);
-        }
+        // JSON-RPC transport: throw a faithful McpError. apiErrorToMcpError
+        // forwards a WordPress JSON-RPC error's original code/data, maps
+        // HTTP-status errors, and surfaces below-HTTP failures with code + hint.
+        // Throwing a plain Error here would let the SDK flatten everything to
+        // -32603 and drop WordPress's real error code.
+        logger.debug(`Converting APIError to McpError for ${config.name} (jsonrpc transport)`, 'MCP', {
+          statusCode: error.statusCode,
+          code: error.code,
+          endpoint: error.endpoint,
+          message: error.message,
+        });
+        throw apiErrorToMcpError(error);
       }
 
-      // For JSON-RPC WordPress errors or non-API errors, re-throw (MCP SDK will handle)
+      // Non-API errors: re-throw (MCP SDK will handle).
       throw error;
     }
   };

--- a/src/lib/session-utils.ts
+++ b/src/lib/session-utils.ts
@@ -6,6 +6,7 @@
 
 import { logger } from './utils.js';
 import { WPRequestParams, MCPRequest, TransportType } from './mcp-types.js';
+import { ConnectionErrorInfo } from './error-utils.js';
 
 /**
  * Session context for the proxy
@@ -20,6 +21,8 @@ export interface SessionContext {
     resolve: () => void;
     settled: boolean;
     failed: boolean;
+    /** Details of the failure when `failed` is true; surfaced to the client. */
+    error?: ConnectionErrorInfo;
   };
 }
 
@@ -98,10 +101,19 @@ export function createSessionContext(): SessionContext {
 /**
  * Signal that initialization completed (success or failure).
  * Unblocks all handlers waiting on waitForInit.
+ *
+ * @param context - The session context.
+ * @param failed  - Whether initialization failed.
+ * @param error   - Failure details to surface to the client (only when failed).
  */
-export function resolveInit(context: SessionContext, failed: boolean): void {
+export function resolveInit(
+  context: SessionContext,
+  failed: boolean,
+  error?: ConnectionErrorInfo
+): void {
   if (context._init.settled) return;
   context._init.failed = failed;
+  context._init.error = failed ? error : undefined;
   context._init.settled = true;
   context._init.resolve();
 }
@@ -113,12 +125,16 @@ const INIT_TIMEOUT_MS = 30_000;
  * Wait for initialization to complete before handling a request.
  * Returns true if the connection is ready, false if init failed or timed out.
  */
-export type InitResult = { ready: true } | { ready: false; reason: 'failed' | 'timeout' };
+export type InitResult =
+  | { ready: true }
+  | { ready: false; reason: 'failed' | 'timeout'; error?: ConnectionErrorInfo };
 
 export async function waitForInit(context: SessionContext, timeoutMs = INIT_TIMEOUT_MS): Promise<InitResult> {
   // Fast path: init already settled, no async work needed
   if (context._init.settled) {
-    return context._init.failed ? { ready: false, reason: 'failed' } : { ready: true };
+    return context._init.failed
+      ? { ready: false, reason: 'failed', error: context._init.error }
+      : { ready: true };
   }
 
   let timer: ReturnType<typeof setTimeout>;
@@ -134,5 +150,7 @@ export async function waitForInit(context: SessionContext, timeoutMs = INIT_TIME
     return { ready: false, reason: 'timeout' };
   }
 
-  return context._init.failed ? { ready: false, reason: 'failed' } : { ready: true };
+  return context._init.failed
+    ? { ready: false, reason: 'failed', error: context._init.error }
+    : { ready: true };
 }

--- a/src/lib/transport-detection.ts
+++ b/src/lib/transport-detection.ts
@@ -6,6 +6,7 @@
 
 import { logger } from './utils.js';
 import { wpRequest, getSessionId } from './wordpress-api.js';
+import { APIError } from './oauth-types.js';
 import { InitializeResult } from './types.js';
 import { TransportType } from './mcp-types.js';
 import { addSessionInfo, SessionContext } from './session-utils.js';
@@ -101,7 +102,21 @@ export async function detectTransportType(context: SessionContext, initParams?: 
     logger.info('✅ JSON-RPC transport detected and working', 'TRANSPORT_DETECT');
     logger.debug('JSON-RPC initialization response:', 'TRANSPORT_DETECT', init);
   } catch (error) {
-    // If JSON-RPC fails, try simple format
+    // A timeout means the upstream is unreachable or stalled, not that it
+    // speaks a different transport. Retrying with simple transport would just
+    // hang for another full timeout, so fail fast and preserve the cause.
+    if (error instanceof APIError && error.code === 'ETIMEDOUT') {
+      logger.error(
+        '❌ JSON-RPC transport timed out; skipping simple transport fallback',
+        'TRANSPORT_DETECT',
+        error
+      );
+      const connectionError = new Error('WordPress connection timed out during initialization');
+      (connectionError as { cause?: unknown }).cause = error;
+      throw connectionError;
+    }
+
+    // If JSON-RPC fails for another reason, try simple format
     logger.warn('⚠️  JSON-RPC transport failed, trying simple transport...', 'TRANSPORT_DETECT');
     logger.debug('JSON-RPC error details:', 'TRANSPORT_DETECT', error);
     
@@ -126,7 +141,13 @@ export async function detectTransportType(context: SessionContext, initParams?: 
       logger.debug('Simple initialization response:', 'TRANSPORT_DETECT', init);
     } catch (simpleError) {
       logger.error('❌ Both JSON-RPC and simple transports failed', 'TRANSPORT_DETECT', simpleError);
-      throw new Error('Unable to establish connection with either transport type');
+      // Preserve the underlying failure as `cause` so the init handler can
+      // surface the real reason (TLS, DNS, refused) instead of a generic message.
+      // Assigned post-construction because the tsconfig lib predates the
+      // two-argument Error constructor.
+      const connectionError = new Error('Unable to establish connection with either transport type');
+      (connectionError as { cause?: unknown }).cause = simpleError;
+      throw connectionError;
     }
   }
   

--- a/src/lib/transport-detection.ts
+++ b/src/lib/transport-detection.ts
@@ -7,6 +7,7 @@
 import { logger } from './utils.js';
 import { wpRequest, getSessionId } from './wordpress-api.js';
 import { APIError } from './oauth-types.js';
+import { isTimeoutCode } from './error-utils.js';
 import { InitializeResult } from './types.js';
 import { TransportType } from './mcp-types.js';
 import { addSessionInfo, SessionContext } from './session-utils.js';
@@ -105,7 +106,9 @@ export async function detectTransportType(context: SessionContext, initParams?: 
     // A timeout means the upstream is unreachable or stalled, not that it
     // speaks a different transport. Retrying with simple transport would just
     // hang for another full timeout, so fail fast and preserve the cause.
-    if (error instanceof APIError && error.code === 'ETIMEDOUT') {
+    // Covers our AbortSignal timeout (ETIMEDOUT) and undici's own connect/
+    // headers deadlines, which can fire first with their own codes.
+    if (error instanceof APIError && isTimeoutCode(error.code)) {
       logger.error(
         '❌ JSON-RPC transport timed out; skipping simple transport fallback',
         'TRANSPORT_DETECT',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -93,8 +93,11 @@ export function log(
 
   const logMessage = `${timestamp} [${levelName}] [${category}] ${message}${formattedArgs ? '\n' + formattedArgs : ''}\n`;
 
-  // Log to stderr to avoid interfering with MCP JSON-RPC communication on stdout
-  if (process.env.LOG_TO_STDERR === 'true') {
+  // Log to stderr to avoid interfering with MCP JSON-RPC communication on stdout.
+  // ERROR-level messages always go to stderr so failures are never silent —
+  // a connection failure must be diagnosable without opting in to LOG_TO_STDERR.
+  // Lower levels stay opt-in to avoid flooding stderr with routine logs.
+  if (level === LogLevel.ERROR || process.env.LOG_TO_STDERR === 'true') {
     process.stderr.write(logMessage);
   }
 

--- a/src/lib/wordpress-api.ts
+++ b/src/lib/wordpress-api.ts
@@ -9,7 +9,11 @@ import { logger, LogLevel } from './utils.js';
 import { CONFIG, validateConfig, getDefaultOAuthScopes, getCustomHeaders } from './config.js';
 import { proxyFetch } from './fetch-utils.js';
 import { WPTokens, AuthError, APIError } from './oauth-types.js';
-import { extractNetworkErrorCode, getConnectionErrorHint } from './error-utils.js';
+import {
+  extractNetworkErrorCode,
+  extractNetworkErrorMessage,
+  getConnectionErrorHint,
+} from './error-utils.js';
 import {
   getValidTokens,
   generateServerUrlHash,
@@ -521,11 +525,11 @@ async function executeWordPressRequest(
     const isTimeout = errorName === 'TimeoutError' || errorName === 'AbortError';
     const code = isTimeout ? 'ETIMEDOUT' : extractNetworkErrorCode(error);
     const hint = getConnectionErrorHint(code);
+    // Prefer the deepest cause message so a TLS detail ("unable to verify the
+    // first certificate") survives instead of undici's generic "fetch failed".
     const errorMessage = isTimeout
       ? `WordPress API request timed out after ${timeoutMs}ms`
-      : error instanceof Error
-        ? error.message
-        : String(error);
+      : extractNetworkErrorMessage(error);
     logger.error(`Error in wpRequest: ${errorMessage}${code ? ` (${code})` : ''}`, 'API');
     if (hint) {
       logger.error(hint, 'API');

--- a/src/lib/wordpress-api.ts
+++ b/src/lib/wordpress-api.ts
@@ -9,6 +9,7 @@ import { logger, LogLevel } from './utils.js';
 import { CONFIG, validateConfig, getDefaultOAuthScopes, getCustomHeaders } from './config.js';
 import { proxyFetch } from './fetch-utils.js';
 import { WPTokens, AuthError, APIError } from './oauth-types.js';
+import { extractNetworkErrorCode, getConnectionErrorHint } from './error-utils.js';
 import {
   getValidTokens,
   generateServerUrlHash,
@@ -422,16 +423,24 @@ async function executeWordPressRequest(
     }
   }
 
+  // Bound the request so a stalled upstream fails fast with a clear error
+  // instead of hanging until the OS TCP timeout. The initialize handshake —
+  // what the MCP client waits on at startup — gets the tighter budget.
+  const timeoutMs = isInitializeRequest(requestData)
+    ? CONFIG.WP_API_INIT_TIMEOUT
+    : CONFIG.WP_API_TIMEOUT;
+
   const fetchOptions: RequestInit = {
     method,
     headers,
     body: JSON.stringify(requestData),
+    signal: AbortSignal.timeout(timeoutMs),
   };
 
   try {
     logger.api('Sending request to WordPress API...');
     logger.debug(`Request URL: ${url}`, 'API');
-    logger.debug(`Request method: ${method}`, 'API');
+    logger.debug(`Request method: ${method} (timeout ${timeoutMs}ms)`, 'API');
     const response = await proxyFetch(url, fetchOptions);
     logger.debug(`Response status: ${response.status}`, 'API');
 
@@ -502,9 +511,26 @@ async function executeWordPressRequest(
       throw error;
     }
 
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    logger.error(`Error in wpRequest: ${errorMessage}`, 'API');
-    throw new APIError(errorMessage, 0, url);
+    // Below-HTTP failure (TLS, DNS, refused, timeout). Surface the underlying
+    // code and an actionable hint so the cause is never swallowed.
+    // AbortSignal.timeout rejects with a DOMException named "TimeoutError"
+    // (node-fetch uses "AbortError"). DOMException is not `instanceof Error` in
+    // Node, so match on the name directly. Normalize to ETIMEDOUT so it carries
+    // a meaningful code and hint.
+    const errorName = (error as { name?: unknown })?.name;
+    const isTimeout = errorName === 'TimeoutError' || errorName === 'AbortError';
+    const code = isTimeout ? 'ETIMEDOUT' : extractNetworkErrorCode(error);
+    const hint = getConnectionErrorHint(code);
+    const errorMessage = isTimeout
+      ? `WordPress API request timed out after ${timeoutMs}ms`
+      : error instanceof Error
+        ? error.message
+        : String(error);
+    logger.error(`Error in wpRequest: ${errorMessage}${code ? ` (${code})` : ''}`, 'API');
+    if (hint) {
+      logger.error(hint, 'API');
+    }
+    throw new APIError(errorMessage, 0, url, undefined, code);
   }
 }
 
@@ -599,8 +625,9 @@ export async function wpRequest(
       throw error;
     }
 
+    const code = extractNetworkErrorCode(error);
     const errorMessage = error instanceof Error ? error.message : String(error);
-    logger.error(`Error in wpRequest: ${errorMessage}`, 'API');
-    throw new APIError(errorMessage, 0, getRequestUrl());
+    logger.error(`Error in wpRequest: ${errorMessage}${code ? ` (${code})` : ''}`, 'API');
+    throw new APIError(errorMessage, 0, getRequestUrl(), undefined, code);
   }
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,6 +8,7 @@ import { validateNodeVersion } from './lib/node-utils.js';
 import { setupFetchPolyfill } from './lib/fetch-utils.js';
 import { detectTransportType } from './lib/transport-detection.js';
 import { createSessionContext, resolveInit } from './lib/session-utils.js';
+import { describeConnectionError } from './lib/error-utils.js';
 import { createWrappedHandler, HANDLER_CONFIGS } from './lib/request-handler-factory.js';
 import { MCP_WORDPRESS_REMOTE_VERSION } from './lib/config.js';
 import {
@@ -114,13 +115,25 @@ async function WordPressProxy() {
         error
       );
 
-      // Mark init as failed and unblock waiting handlers (they'll return errors)
-      resolveInit(sessionContext, true);
+      // Describe the real cause (TLS/DNS/refused) — unwrap the `cause` set by
+      // transport detection — so logs and the client see the underlying error
+      // instead of a generic "connection failed".
+      const cause = (error as { cause?: unknown })?.cause ?? error;
+      const connectionError = describeConnectionError(cause);
+      if (connectionError.hint) {
+        logger.error(connectionError.hint, 'INIT');
+      }
+
+      // Mark init as failed and unblock waiting handlers (they'll return errors
+      // carrying these details to the client).
+      resolveInit(sessionContext, true, connectionError);
 
       const clientProtocolVersion = request?.params?.protocolVersion || '2025-06-18';
 
       // Return a fallback response with empty capabilities so the SDK
-      // doesn't try to list tools/resources/prompts for a dead connection
+      // doesn't try to list tools/resources/prompts for a dead connection.
+      // `experimental.connectionFailed` lets clients detect the degraded state
+      // programmatically rather than string-matching the instructions field.
       const fallbackResponse = {
         protocolVersion: clientProtocolVersion,
         serverInfo: {
@@ -133,8 +146,11 @@ async function WordPressProxy() {
           prompts: {},
           logging: {},
           completions: {},
+          experimental: { connectionFailed: true },
         },
-        instructions: 'MCP WordPress Remote Proxy Server (Connection Failed)',
+        instructions: `MCP WordPress Remote Proxy Server (Connection Failed${
+          connectionError.code ? `: ${connectionError.code}` : ''
+        })`,
       };
 
       logger.warn('⚠️ Using fallback initialize response', 'INIT');

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -134,6 +134,10 @@ async function WordPressProxy() {
       // doesn't try to list tools/resources/prompts for a dead connection.
       // `experimental.connectionFailed` lets clients detect the degraded state
       // programmatically rather than string-matching the instructions field.
+      // The value is an object, not a boolean: the MCP ServerCapabilities schema
+      // requires every `experimental` entry to be an object, and a strict client
+      // would otherwise reject this initialize result. Its presence is the flag;
+      // the underlying code travels in the details below.
       const fallbackResponse = {
         protocolVersion: clientProtocolVersion,
         serverInfo: {
@@ -146,7 +150,7 @@ async function WordPressProxy() {
           prompts: {},
           logging: {},
           completions: {},
-          experimental: { connectionFailed: true },
+          experimental: { connectionFailed: connectionError.code ? { code: connectionError.code } : {} },
         },
         instructions: `MCP WordPress Remote Proxy Server (Connection Failed${
           connectionError.code ? `: ${connectionError.code}` : ''

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -130,14 +130,15 @@ async function WordPressProxy() {
 
       const clientProtocolVersion = request?.params?.protocolVersion || '2025-06-18';
 
-      // Return a fallback response with empty capabilities so the SDK
-      // doesn't try to list tools/resources/prompts for a dead connection.
-      // `experimental.connectionFailed` lets clients detect the degraded state
-      // programmatically rather than string-matching the instructions field.
-      // The value is an object, not a boolean: the MCP ServerCapabilities schema
-      // requires every `experimental` entry to be an object, and a strict client
-      // would otherwise reject this initialize result. Its presence is the flag;
-      // the underlying code travels in the details below.
+      // Return a fallback response that advertises NO real capabilities — only
+      // `experimental.connectionFailed`. The connection is dead, so it cannot
+      // serve tools/resources/prompts/logging/completions; advertising them
+      // makes an eager SDK client call e.g. logging/setLevel during setup, which
+      // then fails and the client reports "Failed to connect" before it can read
+      // the degraded flag. Advertising nothing lets the client complete the
+      // handshake and detect the degraded state via experimental.connectionFailed
+      // (an object, since the MCP schema requires each experimental entry to be
+      // an object; its presence is the flag, the code travels inside).
       const fallbackResponse = {
         protocolVersion: clientProtocolVersion,
         serverInfo: {
@@ -145,11 +146,6 @@ async function WordPressProxy() {
           version: MCP_WORDPRESS_REMOTE_VERSION,
         },
         capabilities: {
-          tools: {},
-          resources: {},
-          prompts: {},
-          logging: {},
-          completions: {},
           experimental: { connectionFailed: connectionError.code ? { code: connectionError.code } : {} },
         },
         instructions: `MCP WordPress Remote Proxy Server (Connection Failed${

--- a/tests/integration/dead-backend.test.ts
+++ b/tests/integration/dead-backend.test.ts
@@ -115,11 +115,15 @@ describe('dead backend integration', () => {
     expect(initResponse).toHaveProperty('id', 1);
     expect(initResponse.result).toBeDefined();
 
-    // Fallback response should have empty capabilities (no tools to list)
+    // The dead connection advertises NO real capabilities — listing tools/
+    // logging/etc. would make an eager client call them during setup and fail
+    // before it can read the degraded flag.
     const caps = initResponse.result.capabilities;
-    expect(caps.tools).toEqual({});
-    expect(caps.resources).toEqual({});
-    expect(caps.prompts).toEqual({});
+    expect(caps.tools).toBeUndefined();
+    expect(caps.resources).toBeUndefined();
+    expect(caps.prompts).toBeUndefined();
+    expect(caps.logging).toBeUndefined();
+    expect(caps.completions).toBeUndefined();
 
     // Instructions should indicate failure
     expect(initResponse.result.instructions).toMatch(/Connection Failed/i);

--- a/tests/integration/dead-backend.test.ts
+++ b/tests/integration/dead-backend.test.ts
@@ -16,6 +16,7 @@
 import { spawn, ChildProcess } from 'child_process';
 import { once } from 'events';
 import { join } from 'path';
+import { InitializeResultSchema } from '@modelcontextprotocol/sdk/types.js';
 
 const PROXY_PATH = join(process.cwd(), 'dist/proxy.js');
 
@@ -124,8 +125,14 @@ describe('dead backend integration', () => {
     expect(initResponse.result.instructions).toMatch(/Connection Failed/i);
 
     // Clients can detect the degraded state programmatically (issue #61)
-    // instead of string-matching the instructions field.
-    expect(caps.experimental).toEqual({ connectionFailed: true });
+    // instead of string-matching the instructions field. The value must be an
+    // object — the MCP ServerCapabilities schema rejects a boolean here.
+    expect(caps.experimental?.connectionFailed).toBeDefined();
+    expect(typeof caps.experimental.connectionFailed).toBe('object');
+
+    // The fallback initialize result must satisfy the SDK schema, or a strict
+    // client would reject the degraded handshake outright.
+    expect(() => InitializeResultSchema.parse(initResponse.result)).not.toThrow();
 
     // 2. Send initialized notification (required by MCP protocol before requests)
     send(proxy, {

--- a/tests/integration/dead-backend.test.ts
+++ b/tests/integration/dead-backend.test.ts
@@ -123,6 +123,10 @@ describe('dead backend integration', () => {
     // Instructions should indicate failure
     expect(initResponse.result.instructions).toMatch(/Connection Failed/i);
 
+    // Clients can detect the degraded state programmatically (issue #61)
+    // instead of string-matching the instructions field.
+    expect(caps.experimental).toEqual({ connectionFailed: true });
+
     // 2. Send initialized notification (required by MCP protocol before requests)
     send(proxy, {
       jsonrpc: '2.0',
@@ -147,6 +151,11 @@ describe('dead backend integration', () => {
     // The init-ready gate should have caught this and returned an error.
     expect(toolsResponse.error).toBeDefined();
     expect(toolsResponse.error.message).toMatch(/WordPress connection failed during initialization/);
+
+    // The error must carry the underlying cause in `data` so the client can
+    // explain why init failed, rather than a bare internal error (issue #61).
+    expect(toolsResponse.error.data).toBeDefined();
+    expect(toolsResponse.error.data.reason).toBe('failed');
   }, 30_000);
 
   // Healthy-backend integration test omitted: unit tests cover the happy path.

--- a/tests/unit/error-utils.test.ts
+++ b/tests/unit/error-utils.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for connection-error classification in error-utils.
+ *
+ * Regression coverage for issue #61: TLS-trust failures (mkcert / DDEV /
+ * corporate CA) must be recognized so the proxy can surface an actionable
+ * hint instead of a silent "connection failed".
+ */
+
+import {
+  extractNetworkErrorCode,
+  getConnectionErrorHint,
+  describeConnectionError,
+} from '../../src/lib/error-utils.js';
+
+describe('error-utils connection error classification', () => {
+  describe('extractNetworkErrorCode', () => {
+    it('reads a code from the top-level error', () => {
+      const err = Object.assign(new Error('boom'), { code: 'ECONNREFUSED' });
+      expect(extractNetworkErrorCode(err)).toBe('ECONNREFUSED');
+    });
+
+    it('walks the cause chain (undici wraps the real error as cause)', () => {
+      // Node `fetch` throws TypeError("fetch failed") with the TLS error in .cause
+      const tlsError = Object.assign(new Error('self-signed'), {
+        code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+      });
+      const fetchError = Object.assign(new TypeError('fetch failed'), { cause: tlsError });
+
+      expect(extractNetworkErrorCode(fetchError)).toBe('UNABLE_TO_VERIFY_LEAF_SIGNATURE');
+    });
+
+    it('returns undefined when no code is present', () => {
+      expect(extractNetworkErrorCode(new Error('no code'))).toBeUndefined();
+      expect(extractNetworkErrorCode('a string')).toBeUndefined();
+    });
+
+    it('stops walking after a bounded depth (no infinite loop on cyclic cause)', () => {
+      const a: any = new Error('a');
+      const b: any = new Error('b');
+      a.cause = b;
+      b.cause = a; // cycle, no codes anywhere
+      expect(extractNetworkErrorCode(a)).toBeUndefined();
+    });
+  });
+
+  describe('getConnectionErrorHint', () => {
+    it.each([
+      'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+      'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+      'SELF_SIGNED_CERT_IN_CHAIN',
+      'DEPTH_ZERO_SELF_SIGNED_CERT',
+    ])('returns the CA-trust hint for %s', code => {
+      const hint = getConnectionErrorHint(code);
+      expect(hint).toContain('NODE_EXTRA_CA_CERTS');
+      expect(hint).toContain('NODE_USE_SYSTEM_CA');
+    });
+
+    it('returns a specific hint for non-trust network codes', () => {
+      expect(getConnectionErrorHint('ENOTFOUND')).toMatch(/resolved/i);
+      expect(getConnectionErrorHint('ECONNREFUSED')).toMatch(/refused/i);
+      expect(getConnectionErrorHint('CERT_HAS_EXPIRED')).toMatch(/expired/i);
+    });
+
+    it('returns undefined for unknown or missing codes', () => {
+      expect(getConnectionErrorHint('SOMETHING_ELSE')).toBeUndefined();
+      expect(getConnectionErrorHint(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('describeConnectionError', () => {
+    it('produces code, message, and hint for a wrapped TLS error', () => {
+      const tlsError = Object.assign(new Error('self-signed certificate in certificate chain'), {
+        code: 'SELF_SIGNED_CERT_IN_CHAIN',
+      });
+      const fetchError = Object.assign(new TypeError('fetch failed'), { cause: tlsError });
+
+      const result = describeConnectionError(fetchError);
+      expect(result.code).toBe('SELF_SIGNED_CERT_IN_CHAIN');
+      expect(result.message).toBe('fetch failed');
+      expect(result.hint).toContain('NODE_EXTRA_CA_CERTS');
+    });
+
+    it('omits the hint for an unrecognized failure', () => {
+      const result = describeConnectionError(new Error('something odd'));
+      expect(result.code).toBeUndefined();
+      expect(result.message).toBe('something odd');
+      expect(result.hint).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/error-utils.test.ts
+++ b/tests/unit/error-utils.test.ts
@@ -8,9 +8,14 @@
 
 import {
   extractNetworkErrorCode,
+  extractNetworkErrorMessage,
   getConnectionErrorHint,
   describeConnectionError,
+  isTimeoutCode,
+  convertAPIErrorToMcpError,
+  apiErrorToMcpError,
 } from '../../src/lib/error-utils.js';
+import { APIError } from '../../src/lib/oauth-types.js';
 
 describe('error-utils connection error classification', () => {
   describe('extractNetworkErrorCode', () => {
@@ -85,6 +90,61 @@ describe('error-utils connection error classification', () => {
       expect(result.code).toBeUndefined();
       expect(result.message).toBe('something odd');
       expect(result.hint).toBeUndefined();
+    });
+  });
+
+  describe('isTimeoutCode', () => {
+    it.each(['ETIMEDOUT', 'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_HEADERS_TIMEOUT'])(
+      'treats %s as a timeout',
+      code => {
+        expect(isTimeoutCode(code)).toBe(true);
+        // Timeout codes also resolve to the timeout hint.
+        expect(getConnectionErrorHint(code)).toMatch(/timed out/i);
+      }
+    );
+
+    it('is false for non-timeout and missing codes', () => {
+      expect(isTimeoutCode('ECONNREFUSED')).toBe(false);
+      expect(isTimeoutCode(undefined)).toBe(false);
+    });
+  });
+
+  describe('extractNetworkErrorMessage', () => {
+    it('returns the deepest cause message, not the wrapper', () => {
+      const leaf = Object.assign(new Error('unable to verify the first certificate'), {
+        code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+      });
+      const wrapper = Object.assign(new TypeError('fetch failed'), { cause: leaf });
+      expect(extractNetworkErrorMessage(wrapper)).toBe('unable to verify the first certificate');
+    });
+
+    it('falls back to the top-level message when there is no cause', () => {
+      expect(extractNetworkErrorMessage(new Error('boom'))).toBe('boom');
+      expect(extractNetworkErrorMessage('a string')).toBe('a string');
+    });
+  });
+
+  describe('MCP error conversion carries the network code and hint', () => {
+    it('maps a timeout APIError to the MCP timeout code with code + hint in data', () => {
+      const err = new APIError('WordPress API request timed out after 120000ms', 0, 'url', undefined, 'ETIMEDOUT');
+
+      const converted = convertAPIErrorToMcpError(err);
+      expect(converted.error.code).toBe(-32001); // TIMEOUT_ERROR
+      expect(converted.error.data.code).toBe('ETIMEDOUT');
+      expect(converted.error.data.hint).toMatch(/timed out/i);
+
+      const mcpError = apiErrorToMcpError(err);
+      expect(mcpError.code).toBe(-32001);
+      expect((mcpError.data as any).code).toBe('ETIMEDOUT');
+      expect((mcpError.data as any).hint).toMatch(/timed out/i);
+    });
+
+    it('falls back to status-based mapping for HTTP errors without a network code', () => {
+      const err = new APIError('Unauthorized', 401, 'url', 'body');
+      const converted = convertAPIErrorToMcpError(err);
+      expect(converted.error.code).toBe(-32010); // UNAUTHORIZED
+      expect(converted.error.data.code).toBeUndefined();
+      expect(converted.error.data.hint).toBeUndefined();
     });
   });
 });

--- a/tests/unit/error-utils.test.ts
+++ b/tests/unit/error-utils.test.ts
@@ -130,8 +130,8 @@ describe('error-utils connection error classification', () => {
 
       const converted = convertAPIErrorToMcpError(err);
       expect(converted.error.code).toBe(-32001); // TIMEOUT_ERROR
-      expect(converted.error.data.code).toBe('ETIMEDOUT');
-      expect(converted.error.data.hint).toMatch(/timed out/i);
+      expect((converted.error.data as any).code).toBe('ETIMEDOUT');
+      expect((converted.error.data as any).hint).toMatch(/timed out/i);
 
       const mcpError = apiErrorToMcpError(err);
       expect(mcpError.code).toBe(-32001);
@@ -139,12 +139,25 @@ describe('error-utils connection error classification', () => {
       expect((mcpError.data as any).hint).toMatch(/timed out/i);
     });
 
-    it('falls back to status-based mapping for HTTP errors without a network code', () => {
-      const err = new APIError('Unauthorized', 401, 'url', 'body');
+    it('maps an HTTP-status error to a sensible MCP code with the status in data', () => {
+      const err = new APIError('WordPress API error (401): Unauthorized', 401, 'url', 'body');
       const converted = convertAPIErrorToMcpError(err);
       expect(converted.error.code).toBe(-32010); // UNAUTHORIZED
-      expect(converted.error.data.code).toBeUndefined();
-      expect(converted.error.data.hint).toBeUndefined();
+      expect((converted.error.data as any).statusCode).toBe(401);
+      expect((converted.error.data as any).code).toBeUndefined();
+      expect((converted.error.data as any).hint).toBeUndefined();
+    });
+
+    it('forwards a WordPress JSON-RPC error verbatim (original code, message, data)', () => {
+      // wpRequest stores WordPress's JSON-RPC error object as the APIError response.
+      const wpError = { code: -32602, message: 'Invalid params', data: { field: 'title' } };
+      const err = new APIError('WordPress JSON-RPC error: Invalid params', -32602, 'url', wpError);
+
+      const mcpError = apiErrorToMcpError(err);
+      // The client must see WordPress's real code, not a flattened -32603.
+      expect(mcpError.code).toBe(-32602);
+      expect(mcpError.message).toMatch(/Invalid params/);
+      expect(mcpError.data).toEqual({ field: 'title' });
     });
   });
 });

--- a/tests/unit/init-ready-gate.test.ts
+++ b/tests/unit/init-ready-gate.test.ts
@@ -74,7 +74,21 @@ describe('init-ready gate', () => {
       resolveInit(context, true);
 
       const result = await waitForInit(context);
-      expect(result).toEqual({ ready: false, reason: 'failed' });
+      expect(result).toEqual({ ready: false, reason: 'failed', error: undefined });
+    });
+
+    it('carries connection error details through the gate', async () => {
+      // Regression for issue #61: the underlying TLS/connection cause must
+      // survive init so handlers can surface it to the client.
+      const connectionError = {
+        code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+        message: 'fetch failed',
+        hint: 'set NODE_EXTRA_CA_CERTS ...',
+      };
+      resolveInit(context, true, connectionError);
+
+      const result = await waitForInit(context);
+      expect(result).toEqual({ ready: false, reason: 'failed', error: connectionError });
     });
 
     it('short-circuits after init already settled', async () => {
@@ -126,6 +140,27 @@ describe('init-ready gate', () => {
       await expect(handler({ params: {} })).rejects.toThrow(
         'Cannot process tools/list: WordPress connection failed during initialization'
       );
+    });
+
+    it('handler surfaces the connection cause in the error data', async () => {
+      // Regression for issue #61: the -32603 error must carry the underlying
+      // cause (code/detail/hint) so the client can show why init failed.
+      const handler = createRequestHandler(HANDLER_CONFIGS.listTools, context);
+
+      resolveInit(context, true, {
+        code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+        message: 'fetch failed',
+        hint: 'set NODE_EXTRA_CA_CERTS or NODE_USE_SYSTEM_CA',
+      });
+
+      const error: any = await handler({ params: {} }).catch((e: any) => e);
+      expect(error.code).toBe(-32603); // ErrorCode.InternalError
+      expect(error.data).toMatchObject({
+        reason: 'failed',
+        code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+        detail: 'fetch failed',
+        hint: 'set NODE_EXTRA_CA_CERTS or NODE_USE_SYSTEM_CA',
+      });
     });
 
     it('handler times out with error when init never completes', async () => {

--- a/tests/unit/init-ready-gate.test.ts
+++ b/tests/unit/init-ready-gate.test.ts
@@ -162,6 +162,28 @@ describe('init-ready gate', () => {
       expect(error.data?.hint).toMatch(/timed out/i);
     });
 
+    it('forwards a WordPress JSON-RPC error code to the client (not flattened to -32603)', async () => {
+      // The proxy must be transparent: WordPress's own error code reaches the
+      // client unchanged, instead of the SDK overwriting it with -32603.
+      nock.cleanAll();
+      nock('https://test-wp.example.com')
+        .post('/?rest_route=/wp/v2/wpmcp')
+        .reply(200, {
+          jsonrpc: '2.0',
+          id: 2,
+          error: { code: -32602, message: 'Invalid params', data: { field: 'title' } },
+        });
+
+      const handler = createWrappedHandler(HANDLER_CONFIGS.listTools, context);
+      context.transportType = 'jsonrpc';
+      resolveInit(context, false);
+
+      const error: any = await handler({ id: 2, params: {} }).catch((e: any) => e);
+      expect(error.code).toBe(-32602); // WordPress's original code, not -32603
+      expect(error.message).toMatch(/Invalid params/);
+      expect(error.data).toEqual({ field: 'title' });
+    });
+
     it('handler surfaces the connection cause in the error data', async () => {
       // Regression for issue #61: the -32603 error must carry the underlying
       // cause (code/detail/hint) so the client can show why init failed.

--- a/tests/unit/init-ready-gate.test.ts
+++ b/tests/unit/init-ready-gate.test.ts
@@ -16,6 +16,7 @@ describe('init-ready gate', () => {
   let prepareRequest: any;
   let waitForInit: any;
   let createRequestHandler: any;
+  let createWrappedHandler: any;
   let HANDLER_CONFIGS: any;
   let context: any;
 
@@ -35,6 +36,7 @@ describe('init-ready gate', () => {
 
     const factoryMod = await import('../../src/lib/request-handler-factory.js');
     createRequestHandler = factoryMod.createRequestHandler;
+    createWrappedHandler = factoryMod.createWrappedHandler;
     HANDLER_CONFIGS = factoryMod.HANDLER_CONFIGS;
   });
 
@@ -140,6 +142,24 @@ describe('init-ready gate', () => {
       await expect(handler({ params: {} })).rejects.toThrow(
         'Cannot process tools/list: WordPress connection failed during initialization'
       );
+    });
+
+    it('surfaces a post-init network failure as an McpError with code and hint', async () => {
+      // Regression for issue #61 (#3): a request-time timeout/network failure
+      // must reach the client with the real code + hint, not a bare -32603.
+      nock.cleanAll();
+      const netErr: any = new Error('Connect Timeout Error');
+      netErr.code = 'ETIMEDOUT';
+      nock('https://test-wp.example.com').post('/?rest_route=/wp/v2/wpmcp').replyWithError(netErr);
+
+      const handler = createWrappedHandler(HANDLER_CONFIGS.listTools, context);
+      context.transportType = 'jsonrpc';
+      resolveInit(context, false);
+
+      const error: any = await handler({ id: 1, params: {} }).catch((e: any) => e);
+      expect(error.code).toBe(-32001); // TIMEOUT_ERROR, not generic -32603
+      expect(error.data?.code).toBe('ETIMEDOUT');
+      expect(error.data?.hint).toMatch(/timed out/i);
     });
 
     it('handler surfaces the connection cause in the error data', async () => {

--- a/tests/unit/transport-detection.test.ts
+++ b/tests/unit/transport-detection.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for transport detection.
+ *
+ * Focus: a timed-out JSON-RPC probe must NOT fall back to simple transport
+ * (issue #61) — retrying a stalled upstream just doubles the wait. Other
+ * JSON-RPC failures should still fall back to simple transport.
+ *
+ * Drives the real wordpress-api through nock (same approach as
+ * init-ready-gate.test.ts) rather than mocking, so the actual timeout and
+ * fallback paths are exercised end to end.
+ */
+
+import { jest } from '@jest/globals';
+import nock from 'nock';
+
+const WP_HOST = 'https://transport-detect.example.com';
+const WP_ENDPOINT = '/?rest_route=/wp/v2/wpmcp';
+const INIT_TIMEOUT_MS = 100;
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe('detectTransportType', () => {
+  let detectTransportType: any;
+
+  beforeAll(async () => {
+    process.env.WP_API_URL = WP_HOST;
+    process.env.JWT_TOKEN = 'test-jwt-for-transport-detection';
+    process.env.NODE_ENV = 'test';
+    // Short init timeout so the timeout test resolves quickly.
+    process.env.WP_API_INIT_TIMEOUT_MS = String(INIT_TIMEOUT_MS);
+
+    jest.resetModules();
+    ({ detectTransportType } = await import('../../src/lib/transport-detection.js'));
+  });
+
+  afterAll(() => {
+    delete process.env.JWT_TOKEN;
+    delete process.env.WP_API_INIT_TIMEOUT_MS;
+    nock.cleanAll();
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    nock.abortPendingRequests();
+    nock.cleanAll();
+  });
+
+  function makeContext(): any {
+    return { sessionId: null, requestIdCounter: 0, transportType: null };
+  }
+
+  it('does not fall back to simple transport when JSON-RPC times out', async () => {
+    // The JSON-RPC probe does not respond within the init timeout. The delay is
+    // kept just above the timeout (not seconds) so nock's reply timer fires and
+    // clears within this test rather than leaking into the worker teardown.
+    const replyDelay = INIT_TIMEOUT_MS + 50;
+    nock(WP_HOST)
+      .post(WP_ENDPOINT)
+      .delay(replyDelay)
+      .reply(200, { jsonrpc: '2.0', id: 1, result: { serverInfo: { name: 'wp' } } });
+
+    const error: any = await detectTransportType(makeContext(), {}).catch((e: any) => e);
+
+    // The "timed out during initialization" message is only produced on the
+    // skip path; the fallback path would say "Unable to establish connection".
+    expect(error.message).toMatch(/timed out during initialization/);
+    expect(error.cause?.code).toBe('ETIMEDOUT');
+
+    // Let nock's delayed reply timer fire and clear before teardown.
+    await sleep(replyDelay + 25);
+  });
+
+  it('falls back to simple transport when JSON-RPC fails for a non-timeout reason', async () => {
+    // First (JSON-RPC) attempt returns a JSON-RPC error, second (simple) succeeds.
+    nock(WP_HOST)
+      .post(WP_ENDPOINT)
+      .reply(200, { jsonrpc: '2.0', id: 1, error: { code: -32601, message: 'no jsonrpc' } });
+    nock(WP_HOST)
+      .post(WP_ENDPOINT)
+      .reply(200, { protocolVersion: '2025-06-18', serverInfo: { name: 'wp' } });
+
+    const result = await detectTransportType(makeContext(), {});
+
+    expect(result.transportType).toBe('simple');
+  });
+
+  it('uses JSON-RPC transport when the first probe succeeds', async () => {
+    nock(WP_HOST)
+      .post(WP_ENDPOINT)
+      .reply(200, {
+        jsonrpc: '2.0',
+        id: 1,
+        result: { protocolVersion: '2025-06-18', serverInfo: { name: 'wp' } },
+      });
+
+    const result = await detectTransportType(makeContext(), {});
+
+    expect(result.transportType).toBe('jsonrpc');
+  });
+});

--- a/tests/unit/transport-detection.test.ts
+++ b/tests/unit/transport-detection.test.ts
@@ -73,6 +73,19 @@ describe('detectTransportType', () => {
     await sleep(replyDelay + 25);
   });
 
+  it('does not fall back when undici reports a connect timeout (UND_ERR_CONNECT_TIMEOUT)', async () => {
+    // undici's own connect deadline can fire before our AbortSignal, surfacing
+    // a different code. It is still a timeout and must be treated as terminal.
+    const connectError: any = new Error('Connect Timeout Error');
+    connectError.code = 'UND_ERR_CONNECT_TIMEOUT';
+    nock(WP_HOST).post(WP_ENDPOINT).replyWithError(connectError);
+
+    const error: any = await detectTransportType(makeContext(), {}).catch((e: any) => e);
+
+    expect(error.message).toMatch(/timed out during initialization/);
+    expect(error.cause?.code).toBe('UND_ERR_CONNECT_TIMEOUT');
+  });
+
   it('falls back to simple transport when JSON-RPC fails for a non-timeout reason', async () => {
     // First (JSON-RPC) attempt returns a JSON-RPC error, second (simple) succeeds.
     nock(WP_HOST)

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -63,6 +63,33 @@ describe('Utils Module', () => {
       expect(process.stderr.write).not.toHaveBeenCalled();
     });
 
+    it('should always write ERROR-level logs to stderr even when LOG_TO_STDERR is not set', async () => {
+      // Regression test for issue #61: init/connection failures were silent
+      // because logs only reached stderr when LOG_TO_STDERR=true. Errors must
+      // always be visible so a failure is self-diagnosable.
+      restoreEnv = mockEnv({});
+
+      const { log, LogLevel } = await import('../../src/lib/utils.js');
+
+      log('Connection failed', LogLevel.ERROR, 'INIT');
+
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringMatching(/\[ERROR\] \[INIT\] Connection failed\n$/)
+      );
+    });
+
+    it('should still gate non-error levels behind LOG_TO_STDERR', async () => {
+      restoreEnv = mockEnv({ LOG_LEVEL: '3' });
+
+      const { log, LogLevel } = await import('../../src/lib/utils.js');
+
+      log('Warn message', LogLevel.WARN, 'TEST');
+      log('Info message', LogLevel.INFO, 'TEST');
+      log('Debug message', LogLevel.DEBUG, 'TEST');
+
+      expect(process.stderr.write).not.toHaveBeenCalled();
+    });
+
     it('should log with default level INFO and category GENERAL', async () => {
       restoreEnv = mockEnv({
         LOG_TO_STDERR: 'true',

--- a/tests/unit/wordpress-api.test.ts
+++ b/tests/unit/wordpress-api.test.ts
@@ -731,6 +731,35 @@ describe('WordPress API Module', () => {
         );
       });
 
+      it('should time out a slow request and report ETIMEDOUT', async () => {
+        // Regression for issue #61: an unbounded fetch let a stalled upstream
+        // hang the initialize handshake for ~60s. The request must now abort.
+        const timeoutMs = 80;
+        const replyDelay = timeoutMs + 50;
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://my-wp-site.com',
+          JWT_TOKEN: 'test-token',
+          WP_API_INIT_TIMEOUT_MS: String(timeoutMs),
+        });
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT)
+          .delay(replyDelay)
+          .reply(200, { status: 'success' });
+
+        const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+        const { isAPIError } = await import('../../src/lib/oauth-types.js');
+
+        const error: any = await wpRequest({ method: 'initialize' }).catch((e: any) => e);
+        expect(isAPIError(error)).toBe(true);
+        expect(error.code).toBe('ETIMEDOUT');
+        expect(error.message).toMatch(/timed out after 80ms/);
+
+        // Let nock's delayed reply timer fire and clear before teardown so it
+        // doesn't leak into the worker (the request was already aborted).
+        await new Promise(resolve => setTimeout(resolve, replyDelay + 25));
+      });
+
       it('should throw APIError for invalid JSON responses', async () => {
         restoreEnv = mockEnv({
           WP_API_URL: 'https://my-wp-site.com',


### PR DESCRIPTION
Fixes #61.

## Problem

When the proxy's `initialize` probe of the WordPress endpoint failed, the failure was invisible and misleading:

1. **Nothing on stderr** — the error was logged, but logs only reached stderr behind an opt-in env var, so a failure produced no output.
2. **Faked success** — the proxy returned a normal-looking `initialize` result, so the client believed the handshake succeeded.
3. **Causeless errors** — every later `tools/list` / `tools/call` failed with a bare `-32603` that named no underlying reason.
4. **Silent ~60s hang** — the `initialize` path used `fetch` with no timeout, so a stalled upstream (TLS handshake hang, blackholed route, dead proxy) blocked until the OS TCP timeout, past the MCP client's limit.

The reported trigger was a WordPress site behind a CA that the OS trusts but Node does not (mkcert/DDEV, corporate CA, VPN).

## Investigation note

The report suspected a custom HTTPS agent ignoring Node's TLS config. That does not hold: `USE_SYSTEM_PROXY` defaults to `false`, so the proxy uses plain native `fetch` — identical TLS to `mcp-remote`, which also relies on the same Node env vars (`NODE_EXTRA_CA_CERTS`, `NODE_USE_SYSTEM_CA`). The certificate rejection is Node's bundled-CA limitation, not a proxy bug. The proxy's real defects were swallowing the error, faking success, and the unbounded fetch.

## What changed

**Surface the failure**
- ERROR-level logs always write to stderr, regardless of `LOG_TO_STDERR`.
- New `error-utils` helpers classify network/TLS errors: walk the `error.cause` chain for the real code (undici hides it there) and map CA-trust codes to an actionable hint.
- The underlying cause flows from init, through the init-ready gate, into the JSON-RPC error `data` (`reason`, `code`, `detail`, `hint`).

**Bound the handshake**
- Requests use `AbortSignal.timeout`. The `initialize` handshake uses `WP_API_INIT_TIMEOUT_MS` (default 25s); other requests use `WP_API_TIMEOUT_MS` (default 120s).
- A timeout normalizes to `ETIMEDOUT` and skips the simple-transport fallback (covering undici's own `UND_ERR_CONNECT_TIMEOUT`), so a stalled upstream fails once, not twice.

**Docs**
- Document the TLS-trust options and the timeouts. Recommend `NODE_EXTRA_CA_CERTS` / `NODE_USE_SYSTEM_CA`; keep `NODE_TLS_REJECT_UNAUTHORIZED=0` only as an explicit insecure last resort.

## Behavior changes (reviewer-facing)

1. **Error codes are forwarded faithfully.** The proxy no longer flattens failures to `-32603`. A WordPress JSON-RPC error keeps its original code and data (e.g. `-32602` stays `-32602`); an HTTP-status error maps to a sensible MCP code (`401 → -32010`) with the status in `data`; a network failure carries its code (`ETIMEDOUT`, etc.) and a hint. Clients will see more specific codes than before.
2. **Degraded `initialize` advertises no real capabilities** — only `experimental.connectionFailed` (an object, as the MCP schema requires). On a dead connection it no longer lists `tools`/`logging`/etc., so an eager SDK client completes the handshake (and can read the flag) instead of failing on an auto `logging/setLevel` call.
3. **Tool-call timeout default of 120s** replaces the previous unbounded behavior. Configurable via `WP_API_TIMEOUT_MS`.

## New environment variables

| Var | Purpose | Default |
|-----|---------|---------|
| `WP_API_INIT_TIMEOUT_MS` | initialize handshake timeout | `25000` |
| `WP_API_TIMEOUT_MS` | tool-call / request timeout | `120000` |
| `LOG_TO_STDERR` | mirror all log levels to stderr (errors always are) | `false` |

(`NODE_EXTRA_CA_CERTS` / `NODE_USE_SYSTEM_CA` are Node-level, now documented for the TLS-trust case.)

## Review

This branch was reviewed by Codex; all findings were addressed: the schema-invalid boolean capability, a too-narrow timeout-code skip, missing error `data`/code mapping, a lost leaf TLS message, and test gaps.

## Validation

- **Unit + integration:** 210 tests pass; `tsc` clean; build clean.
- **Stub harness:** healthy, TLS-untrusted, slow/timeout, dead — all pass.
- **Live, real backend:** healthy init + read-only `tools/call` round-trips against `public-api.wordpress.com` through OAuth and a SOCKS proxy.
- **MCP Inspector (real SDK client):** accepts the degraded `initialize` (the pre-fix boolean would reject it); forwards a backend `-32602` to the client as `-32602`, not `-32603`.
- **Release probes:** packed-artifact install in a clean dir (behaves identically); timeout through the SOCKS path surfaces `AbortError` and is classified as `ETIMEDOUT`; `NODE_EXTRA_CA_CERTS` honored by native `fetch` on Node 18/20/22.

## Not addressed

The fix does not change Node's certificate trust — that remains env-var configuration (now documented). It also does not change which transport WordPress JSON-RPC errors arrive on; it only forwards them faithfully.