### PR TITLE
chore(release): v0.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/mcp-wordpress-remote",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
         "@tootallnate/quickjs-emscripten": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "description": "MCP WordPress Remote proxy server",
   "engines": {
     "node": ">=18.0.0"

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,7 +4,7 @@ import { selectCallbackPort } from './port-utils.js';
 import { logger } from './utils.js';
 
 // Version constant - update this manually when releasing new versions
-export const MCP_WORDPRESS_REMOTE_VERSION = '0.3.0';
+export const MCP_WORDPRESS_REMOTE_VERSION = '0.3.3';
 
 /**
  * Parse a positive integer from an environment variable, falling back to a


### PR DESCRIPTION
Version bump to **0.3.3** in preparation for the release.

## Changes
- `package.json`: 0.3.1 → 0.3.3
- `package-lock.json`: 0.3.1 → 0.3.3 (top + root package entry)
- `src/lib/config.ts` `MCP_WORDPRESS_REMOTE_VERSION`: 0.3.0 → 0.3.3 (this is the version the proxy reports as `serverInfo.version`; it had drifted)

## Why all three must move together
The `Publish to npm on release` workflow verifies the release tag equals `v<package.json version>` and runs `npm ci`. So:
- `package.json` must be 0.3.3 or the v0.3.3 release fails the tag check (this is why **v0.3.2 never published** — its tag didn't match package.json 0.3.1).
- `package-lock.json` must match or `npm ci` fails.

## Release steps (after merge)
1. Merge this PR to trunk.
2. Create a GitHub release with tag **`v0.3.3`** targeting the merge commit, **not** marked as pre-release.
3. The workflow publishes 0.3.3 to npm `latest` via Trusted Publishing (no token needed).

## Note
The existing `v0.3.2` tag + GitHub release are dangling (never published). Worth deleting separately to avoid confusion, but not required for 0.3.3.

Ships the issue #61 fixes already merged in #76.