### PR TITLE
fix: prefer explicit proxy env vars over macOS system proxy

### DIFF
--- a/src/lib/proxy-utils.ts
+++ b/src/lib/proxy-utils.ts
@@ -3,7 +3,7 @@
  *
  * Supports:
  * - macOS: Automatic PAC file detection from system proxy settings
- * - macOS: System SOCKS proxy detection (AutoProxxy Tunnel All Traffic)
+ * - macOS: System SOCKS proxy detection (manual "tunnel all traffic" config)
  * - All platforms: Environment variables (SOCKS_PROXY, HTTPS_PROXY, etc.)
  */
 
@@ -145,16 +145,26 @@ export function detectEnvProxy(): { url: string; type: 'socks' | 'http' } | null
 }
 
 /**
+ * Detector for macOS system proxy settings. Injectable so the precedence
+ * logic in doInitializeProxy() can be tested without shelling out to scutil.
+ */
+type MacOsProxyDetector = () => MacOsProxyInfo | null;
+
+/**
  * Initialize proxy configuration (call once at startup)
  * Guards against concurrent initialization calls
+ *
+ * @param detectMacOs - Optional override for macOS proxy detection (testing seam)
  */
-export async function initializeProxy(): Promise<void> {
+export async function initializeProxy(
+  detectMacOs: MacOsProxyDetector = detectMacOsProxy
+): Promise<void> {
   // Return existing promise if initialization is already in progress
   if (initializationPromise) {
     return initializationPromise;
   }
 
-  initializationPromise = doInitializeProxy().catch((error) => {
+  initializationPromise = doInitializeProxy(detectMacOs).catch((error) => {
     initializationPromise = null;
     throw error;
   });
@@ -164,11 +174,28 @@ export async function initializeProxy(): Promise<void> {
 /**
  * Internal initialization logic
  */
-async function doInitializeProxy(): Promise<void> {
-  // 1. Try macOS system proxy (single scutil call for both PAC and SOCKS)
-  const macProxy = detectMacOsProxy();
+async function doInitializeProxy(detectMacOs: MacOsProxyDetector): Promise<void> {
+  // 1. Explicit environment proxy takes precedence over auto-detected system
+  //    proxies. Setting SOCKS_PROXY/HTTPS_PROXY/ALL_PROXY/HTTP_PROXY is a
+  //    deliberate operator choice — including the URL scheme. The scheme
+  //    matters: socks5:// resolves destination hostnames client-side, while
+  //    socks5h:// defers resolution to the proxy. An auto-detected system PAC
+  //    would otherwise be consulted first and could synthesize a different
+  //    scheme, overriding the operator's explicit choice and changing which
+  //    side performs DNS. Honoring the explicit value verbatim, before the
+  //    system PAC, follows the precedence convention used by curl, git, and
+  //    most HTTP clients.
+  const envProxy = detectEnvProxy();
+  if (envProxy) {
+    proxyConfig = { type: 'env', envProxy };
+    logger.info(`Proxy configured from environment: ${sanitizeProxyUrl(envProxy.url)}`, 'PROXY');
+    return;
+  }
 
-  // 1a. PAC file
+  // 2. Try macOS system proxy (single scutil call for both PAC and SOCKS)
+  const macProxy = detectMacOs();
+
+  // 2a. PAC file
   if (macProxy?.pacUrl) {
     try {
       // Fetch PAC file directly (not through proxy)
@@ -194,21 +221,13 @@ async function doInitializeProxy(): Promise<void> {
     }
   }
 
-  // 1b. SOCKS proxy (e.g. AutoProxxy "Tunnel All Traffic")
+  // 2b. System SOCKS proxy (manual "tunnel all traffic" configuration)
   if (macProxy?.socks) {
     const { host, port } = macProxy.socks;
     const bracketedHost = host.includes(':') ? `[${host}]` : host;
     const socksUrl = `socks5h://${bracketedHost}:${port}`;
     proxyConfig = { type: 'env', envProxy: { url: socksUrl, type: 'socks' } };
     logger.info(`System SOCKS proxy configured: ${sanitizeProxyUrl(socksUrl)}`, 'PROXY');
-    return;
-  }
-
-  // 2. Try environment variables (all platforms)
-  const envProxy = detectEnvProxy();
-  if (envProxy) {
-    proxyConfig = { type: 'env', envProxy };
-    logger.info(`Proxy configured from environment: ${sanitizeProxyUrl(envProxy.url)}`, 'PROXY');
     return;
   }
 

--- a/tests/unit/proxy-init.test.ts
+++ b/tests/unit/proxy-init.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for proxy initialization precedence in doInitializeProxy().
+ *
+ * Guards the rule that an explicit proxy environment variable wins over
+ * auto-detected macOS system proxies. The macOS detector is injected so the
+ * precedence logic is tested without shelling out to scutil.
+ */
+
+import { jest } from '@jest/globals';
+import { mockEnv } from '../utils/test-helpers.js';
+
+// Shape returned by the real detectMacOsProxy(); declared locally because the
+// type is internal to the module under test.
+type MacOsProxyInfo = {
+  pacUrl: string | null;
+  socks: { host: string; port: string } | null;
+};
+
+const NO_PROXY_ENV = {
+  SOCKS_PROXY: '',
+  socks_proxy: '',
+  HTTPS_PROXY: '',
+  https_proxy: '',
+  ALL_PROXY: '',
+  all_proxy: '',
+  HTTP_PROXY: '',
+  http_proxy: '',
+};
+
+describe('doInitializeProxy precedence', () => {
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    if (restoreEnv) restoreEnv();
+  });
+
+  it('explicit env proxy wins over a detected macOS system PAC', async () => {
+    // A system PAC is available, but the explicit env proxy must win and its
+    // scheme (socks5://, client-side DNS) must be honored verbatim.
+    const detectMacOs = jest.fn<() => MacOsProxyInfo | null>(() => ({
+      pacUrl: 'http://pac.example.com/proxy.pac',
+      socks: null,
+    }));
+    restoreEnv = mockEnv({ ...NO_PROXY_ENV, SOCKS_PROXY: 'socks5://127.0.0.1:1080' });
+
+    const proxy = await import('../../src/lib/proxy-utils.js');
+    await proxy.initializeProxy(detectMacOs);
+
+    expect(proxy.getProxyType()).toBe('env');
+    // Explicit env proxy short-circuits system detection.
+    expect(detectMacOs).not.toHaveBeenCalled();
+
+    const agent = await proxy.getAgentForUrl('https://example.com');
+    expect(agent?.constructor.name).toBe('SocksProxyAgent');
+  });
+
+  it('falls back to system proxy detection when no env proxy is set', async () => {
+    const detectMacOs = jest.fn<() => MacOsProxyInfo | null>(() => ({
+      pacUrl: null,
+      socks: null,
+    }));
+    restoreEnv = mockEnv(NO_PROXY_ENV);
+
+    const proxy = await import('../../src/lib/proxy-utils.js');
+    await proxy.initializeProxy(detectMacOs);
+
+    // System detection runs only because no explicit env proxy was present.
+    expect(detectMacOs).toHaveBeenCalledTimes(1);
+    expect(proxy.getProxyType()).toBe('none');
+  });
+});


### PR DESCRIPTION
## What

Reorder proxy source precedence in `doInitializeProxy()` so an explicit proxy environment variable wins over auto-detected macOS system proxies.

- New order: **explicit env proxy** (`SOCKS_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` / `HTTP_PROXY`) → macOS PAC → macOS system SOCKS → none.
- Old order: macOS PAC → macOS system SOCKS → explicit env proxy.
- Add an injectable macOS detector seam to `initializeProxy(detectMacOs?)` (defaults to the real `detectMacOsProxy`) so the precedence logic is testable without shelling out to `scutil`.
- Add a regression test (`tests/unit/proxy-init.test.ts`): explicit env proxy wins over a detected macOS PAC and short-circuits system detection.
- Generalize internal tool names in comments (this is a public repo).

The `socks5h://` synthesis for auto-detected proxies (PAC + system SOCKS) is untouched.

## Why

PR #63 introduced `socks5h://` for PAC-synthesized proxies to fix dual-stack hosts where client-side DNS could pick an IPv6 address the proxy cannot route to. That fix is correct and stays as the default.

Problem: PR #63 forces `socks5h://` for PAC-synthesized proxies, and the macOS system PAC was consulted **before** the operator's explicit `SOCKS_PROXY`. So an explicit `socks5://` (client-side DNS) was silently overridden by the PAC's `socks5h://`. PR #63's own commit message states explicit env proxies "are passed through verbatim so the operator can choose either scheme" — the old ordering broke that whenever a system PAC was present.

The reorder makes that promise true and matches the precedence convention of curl/git/most HTTP clients: an explicit proxy env var beats auto-detected system config. **Default behavior (no explicit env var) is unchanged** — PAC still wins and still forces `socks5h://`.

## Caveat

If a user has BOTH an explicit proxy env var AND relies on the system PAC for per-URL/split routing, they now get the single env proxy instead of PAC routing. `NO_PROXY` bypass still applies (handled later in `getAgentForUrl()`), so direct-connect exclusions are unaffected.

## Note on the test seam

Jest's ESM loader does not intercept the `child_process` builtin in this project's config (verified: both bare `child_process` and `node:child_process` imports hit the real `execSync`). The injectable detector is the narrow seam that makes precedence deterministically testable. Production caller (`fetch-utils.ts`) uses the no-arg form, so the default detector applies — no production behavior change.

## Testing

- `npx tsc --noEmit` — clean
- `npx jest tests/unit/ --no-coverage` — 208/208 pass (27/27 for the two proxy suites)