### PR TITLE
chore(release): v0.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/mcp-wordpress-remote",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
         "@tootallnate/quickjs-emscripten": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "MCP WordPress Remote proxy server",
   "engines": {
     "node": ">=18.0.0"

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,7 +4,7 @@ import { selectCallbackPort } from './port-utils.js';
 import { logger } from './utils.js';
 
 // Version constant - update this manually when releasing new versions
-export const MCP_WORDPRESS_REMOTE_VERSION = '0.3.3';
+export const MCP_WORDPRESS_REMOTE_VERSION = '0.3.4';
 
 /**
  * Parse a positive integer from an environment variable, falling back to a


### PR DESCRIPTION
## What

Bump version to **0.3.4** in `package.json`, `package-lock.json`, and the `MCP_WORDPRESS_REMOTE_VERSION` constant in `src/lib/config.ts`.

## Why

Prepare the 0.3.4 release. This release ships the proxy precedence fix from #78: an explicit `SOCKS_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` / `HTTP_PROXY` now wins over the auto-detected macOS system PAC, so an operator's explicit `socks5://` (client-side DNS) is no longer overridden by the PAC's forced `socks5h://`.

The publish-on-release workflow verifies the release tag equals `v<package.json version>`, so all three version locations must read 0.3.4 before the `v0.3.4` GitHub Release is created.

## Release gate

- `npm run build` — clean
- `npx jest tests/unit/ --no-coverage` — 208/208 pass

## After merge

Create a GitHub Release with tag `v0.3.4` (not prerelease) to trigger publish to the `latest` npm tag.