### PR TITLE
fix(oauth): reuse persisted DCR client instead of re-registering on every connect

### DIFF
--- a/src/lib/mcp-oauth-provider.ts
+++ b/src/lib/mcp-oauth-provider.ts
@@ -237,8 +237,18 @@ export class MCPOAuthProvider {
     // Reuse a previously registered client if one is persisted for this server.
     // Without this, every fresh process with no in-memory clientId would mint a
     // brand-new DCR client and orphan the prior registration server-side.
+    //
+    // This intentionally runs before the OAUTH_DYNAMIC_REGISTRATION guard: that
+    // flag governs minting a *new* client, not reusing one already obtained. A
+    // persisted client_info.json is only ever written by a prior successful
+    // registration, so reusing it is not "performing registration" and remains
+    // valid even when new registration is disabled.
+    //
+    // The explicit string check (rather than a truthiness check) makes a
+    // corrupt-but-JSON-valid file (e.g. a non-string or empty client_id) fall
+    // through to registration instead of promoting a bad value into the auth URL.
     const storedClientInfo = await readClientInfo(this.serverUrlHash);
-    if (storedClientInfo?.client_id) {
+    if (typeof storedClientInfo?.client_id === 'string' && storedClientInfo.client_id.length > 0) {
       this.config.clientId = storedClientInfo.client_id;
       logger.oauth('Reusing persisted client registration, skipping dynamic registration');
       return;

--- a/src/lib/mcp-oauth-provider.ts
+++ b/src/lib/mcp-oauth-provider.ts
@@ -234,6 +234,16 @@ export class MCPOAuthProvider {
       return;
     }
 
+    // Reuse a previously registered client if one is persisted for this server.
+    // Without this, every fresh process with no in-memory clientId would mint a
+    // brand-new DCR client and orphan the prior registration server-side.
+    const storedClientInfo = await readClientInfo(this.serverUrlHash);
+    if (storedClientInfo?.client_id) {
+      this.config.clientId = storedClientInfo.client_id;
+      logger.oauth('Reusing persisted client registration, skipping dynamic registration');
+      return;
+    }
+
     if (!CONFIG.OAUTH_DYNAMIC_REGISTRATION) {
       throw new OAuthError(
         'No client ID provided and dynamic registration is disabled',

--- a/tests/unit/mcp-oauth-provider.test.ts
+++ b/tests/unit/mcp-oauth-provider.test.ts
@@ -35,11 +35,15 @@ describe('MCPOAuthProvider client registration', () => {
     });
     jest.resetModules();
     nock.cleanAll();
+    // Fail fast: any request without a matching interceptor throws instead of
+    // attempting a real connection to example.com.
+    nock.disableNetConnect();
   });
 
   afterEach(() => {
     if (restoreEnv) restoreEnv();
     nock.cleanAll();
+    nock.enableNetConnect();
     if (fsSync.existsSync(tempDir)) {
       fsSync.rmSync(tempDir, { recursive: true, force: true });
     }
@@ -47,10 +51,16 @@ describe('MCPOAuthProvider client registration', () => {
 
   async function loadModules() {
     const { MCPOAuthProvider } = await import('../../src/lib/mcp-oauth-provider.js');
-    const { generateServerUrlHash, writeClientInfo, readClientInfo } = await import(
-      '../../src/lib/persistent-auth-config.js'
-    );
-    return { MCPOAuthProvider, generateServerUrlHash, writeClientInfo, readClientInfo };
+    const { generateServerUrlHash, writeClientInfo, readClientInfo, ensureConfigDir, getConfigFilePath } =
+      await import('../../src/lib/persistent-auth-config.js');
+    return {
+      MCPOAuthProvider,
+      generateServerUrlHash,
+      writeClientInfo,
+      readClientInfo,
+      ensureConfigDir,
+      getConfigFilePath,
+    };
   }
 
   function buildProvider(MCPOAuthProvider: any) {
@@ -78,17 +88,48 @@ describe('MCPOAuthProvider client registration', () => {
 
   it('registers exactly once and persists the result when no client is stored', async () => {
     const { MCPOAuthProvider, generateServerUrlHash, readClientInfo } = await loadModules();
-    const scope = nock(origin).post(registrationPath).reply(201, { client_id: 'new-client-456' });
+    let registerCalls = 0;
+    nock(origin)
+      .post(registrationPath)
+      .reply(201, () => {
+        registerCalls++;
+        return { client_id: 'new-client-456' };
+      });
 
     const provider = buildProvider(MCPOAuthProvider);
     await (provider as any).ensureClientRegistration();
 
-    expect(scope.isDone()).toBe(true); // the single interceptor was consumed exactly once
+    expect(registerCalls).toBe(1); // exactly one /register call, not merely "at least one"
     expect(provider.getConfig().clientId).toBe('new-client-456');
 
     const hash = generateServerUrlHash(serverUrl);
     const persisted = await readClientInfo(hash);
     expect(persisted?.client_id).toBe('new-client-456');
+  });
+
+  it('falls through to registration when stored client_info is corrupt (empty client_id)', async () => {
+    const { MCPOAuthProvider, generateServerUrlHash, readClientInfo, ensureConfigDir, getConfigFilePath } =
+      await loadModules();
+    await ensureConfigDir();
+    const hash = generateServerUrlHash(serverUrl);
+    // Structurally valid JSON but an unusable client_id — must not be promoted.
+    fsSync.writeFileSync(getConfigFilePath(hash, 'client_info.json'), JSON.stringify({ client_id: '' }));
+
+    let registerCalls = 0;
+    nock(origin)
+      .post(registrationPath)
+      .reply(201, () => {
+        registerCalls++;
+        return { client_id: 'fresh-after-corrupt' };
+      });
+
+    const provider = buildProvider(MCPOAuthProvider);
+    await (provider as any).ensureClientRegistration();
+
+    expect(registerCalls).toBe(1); // the empty client_id did not short-circuit registration
+    expect(provider.getConfig().clientId).toBe('fresh-after-corrupt');
+    const persisted = await readClientInfo(hash);
+    expect(persisted?.client_id).toBe('fresh-after-corrupt');
   });
 
   it('reuses the stored client even when tokens are absent/expired (re-auth, not re-register)', async () => {

--- a/tests/unit/mcp-oauth-provider.test.ts
+++ b/tests/unit/mcp-oauth-provider.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for MCPOAuthProvider client registration
+ *
+ * Regression coverage for the orphaned-client bug: the provider must reuse a
+ * persisted DCR registration instead of minting a brand-new client on every
+ * connect attempt. See ensureClientRegistration() in mcp-oauth-provider.ts.
+ */
+
+import { jest } from '@jest/globals';
+import nock from 'nock';
+import tmp from 'tmp';
+import fsSync from 'fs';
+import { mockEnv } from '../utils/test-helpers.js';
+
+// Avoid ESM issues by stubbing the browser-opening dependency.
+jest.unstable_mockModule('open', () => ({
+  default: jest.fn().mockImplementation(() => Promise.resolve()),
+}));
+
+describe('MCPOAuthProvider client registration', () => {
+  const origin = 'https://example.com';
+  const serverUrl = `${origin}/`;
+  const registrationPath = '/oauth/register';
+  const registrationEndpoint = `${origin}${registrationPath}`;
+  let tempDir: string;
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    tempDir = tmp.dirSync({ unsafeCleanup: true }).name;
+    restoreEnv = mockEnv({
+      WP_MCP_CONFIG_DIR: tempDir,
+      WP_API_URL: serverUrl,
+      OAUTH_ENABLED: 'true',
+      OAUTH_DYNAMIC_REGISTRATION: 'true',
+    });
+    jest.resetModules();
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    if (restoreEnv) restoreEnv();
+    nock.cleanAll();
+    if (fsSync.existsSync(tempDir)) {
+      fsSync.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  async function loadModules() {
+    const { MCPOAuthProvider } = await import('../../src/lib/mcp-oauth-provider.js');
+    const { generateServerUrlHash, writeClientInfo, readClientInfo } = await import(
+      '../../src/lib/persistent-auth-config.js'
+    );
+    return { MCPOAuthProvider, generateServerUrlHash, writeClientInfo, readClientInfo };
+  }
+
+  function buildProvider(MCPOAuthProvider: any) {
+    const provider = new MCPOAuthProvider({ serverUrl, scopes: ['read', 'write'] });
+    // ensureClientRegistration() is reached after discovery in the real flow;
+    // inject the discovered metadata directly to isolate the registration step.
+    (provider as any).authServerMetadata = { registration_endpoint: registrationEndpoint };
+    return provider;
+  }
+
+  it('reuses a stored client_id and does not call /register', async () => {
+    const { MCPOAuthProvider, generateServerUrlHash, writeClientInfo } = await loadModules();
+    const hash = generateServerUrlHash(serverUrl);
+    await writeClientInfo(hash, { client_id: 'stored-client-123' });
+
+    // Any hit to the registration endpoint should fail the test.
+    const scope = nock(origin).post(registrationPath).reply(201, { client_id: 'must-not-be-used' });
+
+    const provider = buildProvider(MCPOAuthProvider);
+    await (provider as any).ensureClientRegistration();
+
+    expect(scope.isDone()).toBe(false); // /register was never called
+    expect(provider.getConfig().clientId).toBe('stored-client-123');
+  });
+
+  it('registers exactly once and persists the result when no client is stored', async () => {
+    const { MCPOAuthProvider, generateServerUrlHash, readClientInfo } = await loadModules();
+    const scope = nock(origin).post(registrationPath).reply(201, { client_id: 'new-client-456' });
+
+    const provider = buildProvider(MCPOAuthProvider);
+    await (provider as any).ensureClientRegistration();
+
+    expect(scope.isDone()).toBe(true); // the single interceptor was consumed exactly once
+    expect(provider.getConfig().clientId).toBe('new-client-456');
+
+    const hash = generateServerUrlHash(serverUrl);
+    const persisted = await readClientInfo(hash);
+    expect(persisted?.client_id).toBe('new-client-456');
+  });
+
+  it('reuses the stored client even when tokens are absent/expired (re-auth, not re-register)', async () => {
+    const { MCPOAuthProvider, generateServerUrlHash, writeClientInfo } = await loadModules();
+    const hash = generateServerUrlHash(serverUrl);
+    await writeClientInfo(hash, { client_id: 'stored-client-789' });
+
+    // No tokens are persisted, mimicking expiry/first-run-after-reauth. The
+    // provider must still reuse the registration rather than create a new one.
+    const scope = nock(origin).post(registrationPath).reply(201, { client_id: 'must-not-be-used' });
+
+    const provider = buildProvider(MCPOAuthProvider);
+    await (provider as any).ensureClientRegistration();
+
+    expect(scope.isDone()).toBe(false);
+    expect(provider.getConfig().clientId).toBe('stored-client-789');
+  });
+
+  it('skips both reuse and registration when a client_id is explicitly provided', async () => {
+    const { MCPOAuthProvider } = await loadModules();
+    const scope = nock(origin).post(registrationPath).reply(201, { client_id: 'must-not-be-used' });
+
+    const provider = new MCPOAuthProvider({ serverUrl, clientId: 'env-client', scopes: ['read'] });
+    (provider as any).authServerMetadata = { registration_endpoint: registrationEndpoint };
+
+    await (provider as any).ensureClientRegistration();
+
+    expect(scope.isDone()).toBe(false);
+    expect(provider.getConfig().clientId).toBe('env-client');
+  });
+});


### PR DESCRIPTION
## Problem

The OAuth server has been accumulating large numbers of orphaned Dynamic Client Registration (RFC 7591) records, with a near-100% orphan rate (no owner, no matching token, authorization never completed). The pattern is one client identity re-registering a fresh DCR client on essentially every connect instead of reusing a prior registration.

## Root cause

`MCPOAuthProvider` is the active DCR provider (selected for the OAuth 2.1 `authorization_code` + PKCE defaults in `wordpress-api.ts`). Its `ensureClientRegistration()` gated registration **only** on the in-memory `this.config.clientId`:

```ts
if (this.config.clientId) { /* skip */ return; }
// ...goes straight to DCR /register
```

`this.config.clientId` is seeded solely from `options.clientId` / `WP_OAUTH_CLIENT_ID` at construction and is **never read back from disk**. `readClientInfo` was imported but never called. So any fresh process without an env client ID:

1. mints a brand-new DCR client via `/register`, and
2. overwrites the persisted `client_info.json`, orphaning the prior registration server-side.

If the browser flow is never completed (the common unexpected-re-prompt case), the result is a tokenless orphan. This happens on first run, on missing/expired tokens, and on every run for stateless/ephemeral hosts where the config dir doesn't persist.

## Fix

Read the persisted `client_info.json` for this `serverUrlHash` before hitting `/register`, and reuse a stored `client_id` when present. Registration now runs only when no client has ever been registered for the server — making the path reuse-first.

## Tests

New `tests/unit/mcp-oauth-provider.test.ts` (nock-based, matching the repo's existing pattern):

- stored `client_id` present → **no** `/register` call, stored id reused
- no stored client → **exactly one** `/register` call, result persisted to `client_info.json`
- absent/expired tokens with a stored client → reuse (re-auth, not re-register)
- explicit `client_id` provided → skips both reuse and registration

Full suite green: 212/212.

## Note on the client_name fingerprint

This provider registers with `client_name = "WordPress MCP Remote"` (`mcp-oauth-provider.ts:259`). If orphaned records on the server show a different `client_name`, they originate from a different client identity (e.g. another component or an older release), not this code path — this PR fixes the bug pattern present here, which would otherwise keep producing `"WordPress MCP Remote"` orphans the same way. Any differently-named orphans should be confirmed separately.

## Deliberately deferred (follow-up)

Cross-process registration locking (concurrent starts → at most one registration). The MCP path currently has only an in-process `authPromise` guard; the lockfile coordinator (`coordination.ts`) is wired only into the legacy provider. Reuse-first eliminates the steady-state re-registration entirely and narrows the remaining race to a single cold start with no stored client. Wiring the lock into the MCP path is a larger change touching the coordinator and is kept out of this PR per the repo's commit-discipline rule (every line traces to one goal).

## Known limitations / follow-ups

These came out of review. None block the orphan fix this PR delivers; each is a separate, larger change:

- **No self-heal for a stale `client_id`.** After this change, a persisted `client_id` that the authorization server later rejects (`invalid_client`-class) is reused on every run and never re-registered — the only recovery is deleting `client_info.json`. Closing the loop needs `invalid_client` classification at token exchange (`mcp-oauth-utils.ts` currently keys only on HTTP status) plus a guarded single re-register (`invalidateCredentials('client')` → clear `clientId` → re-run `ensureClientRegistration()`), which is its own flow + test surface. Deferred to a follow-up alongside the cross-process lock.
- **Version-scoped config dir causes once-per-upgrade re-registration.** `client_info.json` lives under `wordpress-remote-${VERSION}`, so a release bump can't find the prior version's file and re-registers (orphaning the old client once per upgrade). This is pre-existing and not introduced here; this PR still cuts orphan creation from "every connect" to "once per version." If cross-version reuse is intended, the client_info path should drop the version segment — separate follow-up.
