### PR TITLE
chore(release): v0.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/mcp-wordpress-remote",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
         "@tootallnate/quickjs-emscripten": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "MCP WordPress Remote proxy server",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Bump version to 0.3.5.

## Changes since v0.3.4

- fix(oauth): reuse persisted DCR client instead of re-registering on every connect (#80)

## Release checklist

- [ ] Merge this PR
- [ ] Create GitHub Release tagged `v0.3.5` (mark as pre-release first to publish canary, then promote to stable)