### PR TITLE
chore: add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "proxy"
   ],
   "author": "Automattic Inc.",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Automattic/mcp-wordpress-remote.git"


### PR DESCRIPTION
## Summary

- add the package `license` field for `@automattic/mcp-wordpress-remote`
- keep the existing repository, files, exports, dependencies, and runtime code unchanged

The repository already includes an MIT `LICENSE`, and the package includes that file in published artifacts. This makes the SPDX license visible through standard npm metadata.

Closes #82.

## Validation

- `node -e "const p=require('./package.json'); if (p.name !== '@automattic/mcp-wordpress-remote' || p.license !== 'MIT') throw new Error(JSON.stringify({name:p.name, license:p.license})); console.log(JSON.stringify({name:p.name, version:p.version, license:p.license, repository:p.repository, bugs:p.bugs, homepage:p.homepage}))"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`

The dry-run package includes `LICENSE`, `README.md`, and the updated `package.json`.
