### PR TITLE
Add localhost OAuth landing page before authorization redirect

### DIFF
--- a/Docs/development.md
+++ b/Docs/development.md
@@ -38,6 +38,7 @@ npm install
 - `npm run build` - Build the project
 - `npm run build:watch` - Watch for changes and rebuild automatically
 - `npm run start` - Same as above
+- `npm run dev:oauth-html` - Build and start a localhost server to preview OAuth HTML (landing, callback, implicit flows). Open the printed URL (default `http://127.0.0.1:8765/`). If that port is busy, the next free port is used (up to +30) and a message is printed. Override the first port to try with `OAUTH_HTML_PREVIEW_PORT` / host with `OAUTH_HTML_PREVIEW_HOST`.
 - `npm run check` - Run type checking and linting
 - `npm run test` - Run tests
 - `npm run test:watch` - Run tests in watch mode

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ OAuth 2.1 provides the most secure and user-friendly experience with full MCP Au
 - No need to manage passwords
 - Automatic expiration handling
 
+By default, your browser opens a **localhost landing page** first (`/oauth/start` on the callback server). You review the context, then click through to the real OAuth authorization URL. This avoids an immediate redirect to the IdP and reduces surprise / phishing risk. To restore the previous behavior (open the authorization URL directly), set `OAUTH_LANDING_PAGE=false`.
+
 ### 2. JWT Token Authentication
 
 For server-to-server authentication or when OAuth is not available.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "check": "prettier --check . && tsc",
     "start": "NODE_ENV=development tsup --watch",
     "dev": "NODE_ENV=development node dist/proxy.js",
+    "dev:oauth-html": "npm run build && node dist/dev/oauth-html-preview.js",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:unit": "jest --testPathPattern=unit",
@@ -90,7 +91,8 @@
   "tsup": {
     "entry": [
       "src/proxy.ts",
-      "src/lib.ts"
+      "src/lib.ts",
+      "src/dev/oauth-html-preview.ts"
     ],
     "format": [
       "esm"

--- a/src/dev/oauth-html-preview.ts
+++ b/src/dev/oauth-html-preview.ts
@@ -1,0 +1,152 @@
+/**
+ * Dev-only: serve OAuth HTML flows in the browser without MCP or WordPress.
+ *
+ * Usage: npm run dev:oauth-html
+ * Env: OAUTH_HTML_PREVIEW_HOST (default 127.0.0.1), OAUTH_HTML_PREVIEW_PORT (default 8765).
+ * If the preferred port is in use, the next free port is tried (up to +30) and a line is printed.
+ */
+
+import http from 'node:http';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import {
+  buildOAuthLandingHtml,
+  buildLandingUnavailableHtml,
+  AUTHORIZATION_CODE_HTML,
+  OAUTH_PAGE_SHARED_CSS,
+} from '../lib/oauth-html-templates.js';
+
+const HOST = process.env.OAUTH_HTML_PREVIEW_HOST || '127.0.0.1';
+const PREFERRED_PORT = Number(process.env.OAUTH_HTML_PREVIEW_PORT) || 8765;
+
+/** Query param: authorization code that triggers a simulated failed POST (tests error UI). */
+const PREVIEW_FAIL_CODE = '__preview_fail__';
+
+const app = express();
+app.use(express.json());
+
+function previewBase(req: express.Request): string {
+  const host = req.get('host') || `${HOST}:${PREFERRED_PORT}`;
+  return `${req.protocol}://${host}`;
+}
+
+function buildMockAuthorizeUrl(base: string): string {
+  return (
+    'https://public-api.wordpress.com/oauth/authorize?' +
+    new URLSearchParams({
+      client_id: 'dev_preview',
+      response_type: 'code',
+      state: 'dev_state',
+      redirect_uri: `${base}/oauth/callback`,
+    }).toString()
+  );
+}
+
+app.get('/', (req, res) => {
+  const base = previewBase(req);
+  const implicitSuccess = `${base}/oauth/callback#access_token=preview_token&token_type=Bearer&expires_in=3600&state=s1`;
+  const implicitError = `${base}/oauth/callback#error=access_denied&error_description=User%20cancelled`;
+  const portLabel = req.get('host')?.split(':').pop() ?? String(PREFERRED_PORT);
+
+  res.type('html').send(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OAuth HTML preview (dev)</title>
+  <style>${OAUTH_PAGE_SHARED_CSS}</style>
+</head>
+<body class="a8c-oauth-page">
+  <div class="a8c-oauth-wrap a8c-oauth-dev-index">
+    <main class="a8c-oauth-card" role="main">
+      <h1 class="a8c-oauth-title">OAuth HTML preview</h1>
+      <p class="a8c-oauth-lead">Same templates as production (<span class="a8c-oauth-code">oauth-html-templates.ts</span>). POST handlers are mocked (no token storage).</p>
+      <ul>
+        <li><a href="/oauth/start">Landing page</a> — continue link uses a fake authorize URL</li>
+        <li><a href="/preview/unavailable">Session not ready</a> (HTTP 400, same body as production)</li>
+        <li><a href="/oauth/callback">Callback shell</a> — no query/hash → &quot;no code&quot; client error</li>
+        <li><a href="/oauth/callback?code=mock_code&amp;state=dev_state">Callback</a> — auth code → mock POST success</li>
+        <li><a href="/oauth/callback?code=${PREVIEW_FAIL_CODE}&amp;state=x">Callback</a> — simulated POST failure</li>
+        <li><a href="/oauth/callback?error=access_denied&amp;error_description=User%20cancelled">Callback</a> — OAuth error (query)</li>
+        <li><a href="${implicitSuccess}">Implicit success</a> (hash)</li>
+        <li><a href="${implicitError}">Implicit error</a> (hash)</li>
+      </ul>
+      <p class="a8c-oauth-dev-note">Listening on port <span class="a8c-oauth-code">${portLabel}</span> · Set <span class="a8c-oauth-code">OAUTH_HTML_PREVIEW_PORT</span> for the first port to try.</p>
+    </main>
+  </div>
+</body>
+</html>`);
+});
+
+app.get('/oauth/start', (req, res) => {
+  const base = previewBase(req);
+  res.type('html').send(buildOAuthLandingHtml(buildMockAuthorizeUrl(base), 'mysite.wordpress.com'));
+});
+
+app.get('/preview/unavailable', (_req, res) => {
+  res.status(400).type('html').send(buildLandingUnavailableHtml());
+});
+
+app.get('/oauth/callback', (_req, res) => {
+  res.type('html').send(AUTHORIZATION_CODE_HTML);
+});
+
+app.post('/oauth/callback', (req, res) => {
+  const code = req.body?.code as string | undefined;
+  if (code === PREVIEW_FAIL_CODE) {
+    res.status(400).json({ error: 'Simulated token exchange failure (dev preview)' });
+    return;
+  }
+  res.json({ success: true, message: 'Authorization code received successfully' });
+});
+
+app.post('/oauth/tokens', (_req, res) => {
+  res.json({ success: true, message: 'Tokens saved successfully' });
+});
+
+async function startServer(): Promise<void> {
+  const maxPort = PREFERRED_PORT + 30;
+
+  for (let port = PREFERRED_PORT; port <= maxPort; port++) {
+    const server = http.createServer(app);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (err: NodeJS.ErrnoException) => {
+          server.removeListener('listening', onListening);
+          reject(err);
+        };
+        const onListening = () => {
+          server.removeListener('error', onError);
+          resolve();
+        };
+        server.once('error', onError);
+        server.once('listening', onListening);
+        server.listen(port, HOST);
+      });
+
+      const addr = server.address() as AddressInfo;
+      const actualPort = addr.port;
+      if (actualPort !== PREFERRED_PORT) {
+        process.stdout.write(`Port ${PREFERRED_PORT} in use; using ${actualPort} instead.\n`);
+      }
+      process.stdout.write(`OAuth HTML preview → http://${HOST}:${actualPort}/\n`);
+      return;
+    } catch (e: unknown) {
+      const err = e as NodeJS.ErrnoException;
+      if (err.code === 'EADDRINUSE') {
+        server.close();
+        continue;
+      }
+      throw e;
+    }
+  }
+
+  throw new Error(
+    `No free port found between ${PREFERRED_PORT} and ${maxPort} (set OAUTH_HTML_PREVIEW_PORT or free a port)`
+  );
+}
+
+startServer().catch(err => {
+  process.stderr.write(String(err) + '\n');
+  process.exit(1);
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -36,6 +36,8 @@ export const CONFIG = {
     ? parseInt(process.env.OAUTH_CALLBACK_PORT)
     : undefined,
   OAUTH_HOST: process.env.OAUTH_HOST || '127.0.0.1',
+  /** When true (default), opens browser to a localhost landing page before the OAuth URL */
+  OAUTH_LANDING_PAGE: process.env.OAUTH_LANDING_PAGE !== 'false',
   WP_OAUTH_CLIENT_ID: process.env.WP_OAUTH_CLIENT_ID || '', // No default - site-specific
 
   // OAuth flow type - authorization_code (recommended) or implicit (legacy)
@@ -109,6 +111,9 @@ export const getConfig = () => ({
 
   /** Hostname for OAuth callback */
   oauthHost: CONFIG.OAUTH_HOST,
+
+  /** Show localhost landing page before redirecting to OAuth (set OAUTH_LANDING_PAGE=false to skip) */
+  oauthLandingPage: CONFIG.OAUTH_LANDING_PAGE,
 
   /** WordPress OAuth client ID */
   wpOAuthClientId: CONFIG.WP_OAUTH_CLIENT_ID,

--- a/src/lib/mcp-oauth-provider.ts
+++ b/src/lib/mcp-oauth-provider.ts
@@ -39,7 +39,10 @@ import {
   buildAuthorizationUrl,
   generateSecureState,
 } from './mcp-oauth-utils.js';
-import { setupWPOAuthCallbackServer } from './oauth-callback-server.js';
+import {
+  setupWPOAuthCallbackServer,
+  formatSiteLabelForOAuthLanding,
+} from './oauth-callback-server.js';
 import { logger } from './utils.js';
 import { CONFIG, getDefaultOAuthScopes, getOAuthCallbackPort, getCustomHeaders } from './config.js';
 import { proxyFetch } from './fetch-utils.js';
@@ -388,15 +391,28 @@ export class MCPOAuthProvider {
       logger.oauth('Built OAuth 2.1 authorization URL');
       logger.debug('Authorization URL', 'OAUTH', { url: authUrl });
 
-      // Step 6: Open browser for user authorization
+      callbackServer.setLandingContext(
+        authUrl,
+        formatSiteLabelForOAuthLanding(this.config.serverUrl)
+      );
+      const urlToOpen = CONFIG.OAUTH_LANDING_PAGE ? callbackServer.getLandingUrl() : authUrl;
+
+      // Step 6: Open browser (localhost landing page first, or authorize URL if disabled)
       try {
-        await open(authUrl);
+        await open(urlToOpen);
         logger.oauth('Browser opened successfully');
       } catch (browserError) {
         logger.error('Failed to open browser automatically', 'OAUTH', browserError);
         logger.info('\n=== MANUAL ACTION REQUIRED ===');
-        logger.info('Please manually open the following URL in your browser:');
-        logger.info(`${authUrl}`);
+        if (CONFIG.OAUTH_LANDING_PAGE) {
+          logger.info('Open this page in your browser (review, then continue to OAuth):');
+          logger.info(`${callbackServer.getLandingUrl()}`);
+          logger.info('Or open the authorization URL directly:');
+          logger.info(`${authUrl}`);
+        } else {
+          logger.info('Please manually open the following URL in your browser:');
+          logger.info(`${authUrl}`);
+        }
         logger.info('===============================\n');
       }
 

--- a/src/lib/oauth-callback-server.ts
+++ b/src/lib/oauth-callback-server.ts
@@ -8,199 +8,31 @@ import { EventEmitter } from 'node:events';
 import { OAuthCallbackServerOptions, WPTokens, OAuthError } from './oauth-types.js';
 import { writeTokens } from './persistent-auth-config.js';
 import { logger } from './utils.js';
+import {
+  buildOAuthLandingHtml,
+  buildLandingUnavailableHtml,
+  AUTHORIZATION_CODE_HTML,
+} from './oauth-html-templates.js';
 
 /**
- * HTML page for handling OAuth 2.1 authorization code callback
- * Updated for MCP Authorization specification 2025-06-18 compliance
+ * Human-readable site label for the OAuth landing page (hostname preferred).
  */
-const AUTHORIZATION_CODE_HTML = `
-<!DOCTYPE html>
-<html>
-<head>
-    <title>MCP Client Authorization</title>
-    <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            margin: 0;
-            padding: 40px;
-            background: #f5f5f5;
-            min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        .container {
-            background: white;
-            padding: 40px;
-            border-radius: 12px;
-            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
-            text-align: center;
-            max-width: 500px;
-            width: 100%;
-        }
-        h1 {
-            color: #333;
-            margin-bottom: 20px;
-        }
-        .success { 
-            color: #27ae60; 
-            font-size: 18px;
-            margin: 20px 0;
-        }
-        .error { 
-            color: #e74c3c; 
-            font-size: 18px;
-            margin: 20px 0;
-        }
-        .loading { 
-            color: #3498db; 
-            font-size: 18px;
-            margin: 20px 0;
-        }
-        .details {
-            color: #666;
-            margin-top: 10px;
-            font-size: 14px;
-        }
-        .spinner {
-            border: 3px solid #f3f3f3;
-            border-top: 3px solid #3498db;
-            border-radius: 50%;
-            width: 30px;
-            height: 30px;
-            animation: spin 1s linear infinite;
-            margin: 20px auto;
-        }
-        @keyframes spin {
-            0% { transform: rotate(0deg); }
-            100% { transform: rotate(360deg); }
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <h1>MCP Client Authorization</h1>
-        <div class="spinner" id="spinner"></div>
-        <div id="status" class="loading">Processing authorization code...</div>
-        <div id="details" class="details"></div>
-    </div>
-
-    <script>
-        function displayStatus(message, type = 'loading') {
-            const statusEl = document.getElementById('status');
-            const spinnerEl = document.getElementById('spinner');
-            
-            statusEl.textContent = message;
-            statusEl.className = type;
-            
-            if (type !== 'loading') {
-                spinnerEl.style.display = 'none';
-            }
-        }
-
-        function displayDetails(message) {
-            document.getElementById('details').textContent = message;
-        }
-
-        // Handle both OAuth 2.1 authorization code flow and implicit flow
-        const urlParams = new URLSearchParams(window.location.search);
-        const hashParams = new URLSearchParams(window.location.hash.substring(1));
-
-        // Check for authorization code first (OAuth 2.1 flow)
-        if (urlParams.has('code')) {
-            const authData = {
-                code: urlParams.get('code'),
-                state: urlParams.get('state'),
-                // Additional parameters for validation
-                iss: urlParams.get('iss'),
-            };
-
-            // Send authorization code to server for token exchange
-            fetch('/oauth/callback', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(authData)
-            })
-            .then(response => {
-                if (response.ok) {
-                    displayStatus('✅ Authorization successful!', 'success');
-                    displayDetails('You can safely close this window.');
-                } else {
-                    return response.json().then(err => {
-                        throw new Error(err.error || 'Failed to exchange authorization code');
-                    });
-                }
-            })
-            .catch(error => {
-                displayStatus('❌ Error completing authorization', 'error');
-                displayDetails(error.message + '. Please try again.');
-            });
-        } 
-        // Check for access token in URL fragment (implicit flow)
-        else if (hashParams.has('access_token')) {
-            const tokens = {
-                access_token: hashParams.get('access_token'),
-                token_type: hashParams.get('token_type') || 'Bearer',
-                expires_in: hashParams.get('expires_in') ? parseInt(hashParams.get('expires_in')) : 3600,
-                scope: hashParams.get('scope'),
-                state: hashParams.get('state'),
-                obtained_at: Date.now()
-            };
-
-            // Send tokens to server for storage
-            fetch('/oauth/tokens', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(tokens)
-            })
-            .then(response => {
-                if (response.ok) {
-                    displayStatus('✅ Authorization successful!', 'success');
-                    displayDetails('You can safely close this window.');
-                } else {
-                    return response.json().then(err => {
-                        throw new Error(err.error || 'Failed to store access token');
-                    });
-                }
-            })
-            .catch(error => {
-                displayStatus('❌ Error completing authorization', 'error');
-                displayDetails(error.message + '. Please try again.');
-            });
-        } 
-        // Check for errors in query parameters
-        else if (urlParams.has('error')) {
-            const error = urlParams.get('error');
-            const errorDescription = urlParams.get('error_description');
-            displayStatus('❌ Authorization failed', 'error');
-            displayDetails(\`Error: \${error}\${errorDescription ? ' - ' + errorDescription : ''}\`);
-        } 
-        // Check for errors in URL fragment (implicit flow errors)
-        else if (hashParams.has('error')) {
-            const error = hashParams.get('error');
-            const errorDescription = hashParams.get('error_description');
-            displayStatus('❌ Authorization failed', 'error');
-            displayDetails(\`Error: \${error}\${errorDescription ? ' - ' + errorDescription : ''}\`);
-        } 
-        // No authorization code or access token found
-        else {
-            displayStatus('❌ No authorization code or access token received', 'error');
-            displayDetails('Please try the authorization process again.');
-        }
-    </script>
-</body>
-</html>
-`;
+export function formatSiteLabelForOAuthLanding(serverUrl: string): string {
+  try {
+    const u = new URL(serverUrl);
+    return u.host;
+  } catch {
+    return serverUrl;
+  }
+}
 
 export class OAuthCallbackServer {
   private app: express.Application;
   private server: Server | null = null;
   private events: EventEmitter;
   private options: OAuthCallbackServerOptions;
+  private landingAuthUrl: string | null = null;
+  private landingSiteLabel: string = '';
 
   constructor(options: OAuthCallbackServerOptions, events: EventEmitter) {
     this.options = options;
@@ -209,9 +41,35 @@ export class OAuthCallbackServer {
     this.setupRoutes();
   }
 
+  /**
+   * Set context for GET /oauth/start (localhost landing page before the OAuth authorize URL).
+   * Call after building the authorization URL and before opening the browser.
+   */
+  setLandingContext(authUrl: string, siteLabel: string): void {
+    this.landingAuthUrl = authUrl;
+    this.landingSiteLabel = siteLabel;
+  }
+
+  /**
+   * URL of the localhost landing page (opens in the browser instead of the authorize URL when enabled).
+   */
+  getLandingUrl(): string {
+    return `http://${this.options.host}:${this.options.port}/oauth/start`;
+  }
+
   private setupRoutes(): void {
     // Parse JSON bodies
     this.app.use(express.json());
+
+    // Localhost landing page: user confirms before visiting the OAuth authorize URL
+    this.app.get('/oauth/start', (req, res) => {
+      logger.oauth('OAuth landing page requested');
+      if (!this.landingAuthUrl) {
+        res.status(400).type('html').send(buildLandingUnavailableHtml());
+        return;
+      }
+      res.type('html').send(buildOAuthLandingHtml(this.landingAuthUrl, this.landingSiteLabel));
+    });
 
     // Serve the authorization code callback page
     this.app.get('/oauth/callback', (req, res) => {
@@ -327,6 +185,8 @@ export class OAuthCallbackServer {
   }
 
   async stop(): Promise<void> {
+    this.landingAuthUrl = null;
+    this.landingSiteLabel = '';
     if (!this.server) return;
     const server = this.server;
     this.server = null;

--- a/src/lib/oauth-html-templates.ts
+++ b/src/lib/oauth-html-templates.ts
@@ -1,0 +1,378 @@
+/**
+ * OAuth-related HTML used by the callback server and dev preview.
+ * Kept separate so `dev:oauth-html` can bundle without the full MCP stack.
+ *
+ * Visual style aligns with Automattic’s public pages (e.g. Press) — clean editorial
+ * layout, neutral background, readable type. See https://automattic.com/press/
+ */
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Shared CSS for OAuth static pages — consistent with automattic.com editorial styling
+ * (light canvas, high-contrast body text, blue interactive accents).
+ */
+export const OAUTH_PAGE_SHARED_CSS = `
+  .a8c-oauth-page {
+    box-sizing: border-box;
+    margin: 0;
+    min-height: 100vh;
+    padding: clamp(1.5rem, 5vw, 3rem) 1.25rem;
+    background: #fafafa;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu,
+      Cantarell, "Helvetica Neue", sans-serif;
+    font-size: 16px;
+    line-height: 1.65;
+    color: #1d2327;
+    -webkit-font-smoothing: antialiased;
+  }
+  .a8c-oauth-page *,
+  .a8c-oauth-page *::before,
+  .a8c-oauth-page *::after {
+    box-sizing: border-box;
+  }
+  .a8c-oauth-wrap {
+    max-width: 40rem;
+    margin: 0 auto;
+  }
+  .a8c-oauth-card {
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-radius: 2px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    padding: clamp(1.75rem, 4vw, 2.5rem);
+  }
+  .a8c-oauth-card--center {
+    text-align: center;
+  }
+  .a8c-oauth-title {
+    margin: 0 0 0.75rem;
+    font-size: clamp(1.375rem, 2.5vw, 1.625rem);
+    font-weight: 600;
+    line-height: 1.25;
+    color: #101517;
+    letter-spacing: -0.02em;
+  }
+  .a8c-oauth-lead {
+    margin: 0 0 1rem;
+    font-size: 1rem;
+    color: #50575e;
+  }
+  .a8c-oauth-lead:last-child {
+    margin-bottom: 0;
+  }
+  .a8c-oauth-site {
+    font-weight: 600;
+    color: #1d2327;
+    word-break: break-word;
+  }
+  .a8c-oauth-notice {
+    margin: 1.5rem 0;
+    padding: 1rem 1.125rem;
+    background: #f0f6fc;
+    border-left: 4px solid #3858e9;
+    font-size: 0.9375rem;
+    color: #1d2327;
+    line-height: 1.55;
+  }
+  .a8c-oauth-actions {
+    margin: 1.5rem 0 0;
+  }
+  .a8c-oauth-btn {
+    display: inline-block;
+    padding: 0.625rem 1.25rem;
+    background: #3858e9;
+    color: #fff !important;
+    text-decoration: none;
+    border-radius: 2px;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    line-height: 1.4;
+    border: none;
+    cursor: pointer;
+    transition: background 0.15s ease;
+  }
+  .a8c-oauth-btn:hover {
+    background: #213fd4;
+  }
+  .a8c-oauth-btn:focus-visible {
+    outline: 2px solid #3858e9;
+    outline-offset: 2px;
+  }
+  .a8c-oauth-muted {
+    margin: 1.25rem 0 0;
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    color: #646970;
+  }
+  .a8c-oauth-code {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.8125rem;
+    color: #50575e;
+    word-break: break-all;
+  }
+  .a8c-oauth-footer-note {
+    margin: 1.5rem 0 0;
+    font-size: 0.8125rem;
+    color: #787c82;
+    text-align: center;
+    max-width: 40rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .a8c-oauth-spinner {
+    border: 3px solid #dcdcde;
+    border-top-color: #3858e9;
+    border-radius: 50%;
+    width: 2rem;
+    height: 2rem;
+    animation: a8c-oauth-spin 0.85s linear infinite;
+    margin: 0 auto 1rem;
+  }
+  @keyframes a8c-oauth-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  .a8c-oauth-status {
+    font-size: 1rem;
+    font-weight: 500;
+    margin: 0.5rem 0;
+  }
+  .a8c-oauth-status--loading {
+    color: #50575e;
+  }
+  .a8c-oauth-status--success {
+    color: #008a20;
+  }
+  .a8c-oauth-status--error {
+    color: #d63638;
+  }
+  .a8c-oauth-details {
+    margin-top: 0.75rem;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    color: #646970;
+  }
+  .a8c-oauth-dev-index a {
+    color: #3858e9;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .a8c-oauth-dev-index a:hover {
+    color: #213fd4;
+  }
+  .a8c-oauth-dev-index ul {
+    margin: 1rem 0 0;
+    padding-left: 1.25rem;
+    line-height: 1.75;
+    color: #50575e;
+  }
+  .a8c-oauth-dev-note {
+    margin-top: 1.5rem;
+    font-size: 0.875rem;
+    color: #646970;
+  }
+`;
+
+export function buildOAuthLandingHtml(authUrl: string, siteLabel: string): string {
+  const safeUrl = escapeHtml(authUrl);
+  const safeSite = escapeHtml(siteLabel);
+  let authHost = '';
+  try {
+    authHost = escapeHtml(new URL(authUrl).hostname);
+  } catch {
+    /* ignore */
+  }
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Continue to WordPress authorization</title>
+  <style>${OAUTH_PAGE_SHARED_CSS}</style>
+</head>
+<body class="a8c-oauth-page">
+  <div class="a8c-oauth-wrap">
+    <main class="a8c-oauth-card" role="main">
+      <h1 class="a8c-oauth-title">Connect WordPress</h1>
+      <p class="a8c-oauth-lead">MCP WordPress Remote on your computer is asking to sign in so it can access your site.</p>
+      <p class="a8c-oauth-lead">Site: <span class="a8c-oauth-site">${safeSite}</span></p>
+      ${
+        authHost
+          ? `<p class="a8c-oauth-muted" style="margin-top:0">You will be sent to <strong>${authHost}</strong> to approve access.</p>`
+          : ''
+      }
+      <div class="a8c-oauth-notice">
+        Only click below if <strong>you</strong> just started this from your AI assistant or terminal on this machine.
+        If this tab opened unexpectedly, close it.
+      </div>
+      <p class="a8c-oauth-actions"><a class="a8c-oauth-btn" href="${safeUrl}">Continue to authorization</a></p>
+      <p class="a8c-oauth-muted">This page is served only from your device (<span class="a8c-oauth-code">127.0.0.1</span>). It is not hosted by WordPress.com or your site.</p>
+    </main>
+  </div>
+</body>
+</html>`;
+}
+
+export function buildLandingUnavailableHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Authorization unavailable</title>
+  <style>${OAUTH_PAGE_SHARED_CSS}</style>
+</head>
+<body class="a8c-oauth-page">
+  <div class="a8c-oauth-wrap">
+    <main class="a8c-oauth-card" role="main">
+      <h1 class="a8c-oauth-title">Session not ready</h1>
+      <p class="a8c-oauth-lead">This authorization step has expired or was already completed. Close this tab and start sign-in again from your AI assistant.</p>
+    </main>
+  </div>
+</body>
+</html>`;
+}
+
+/**
+ * HTML page for handling OAuth 2.1 authorization code callback (and implicit flow client JS).
+ * MCP Authorization specification 2025-06-18 compliance.
+ */
+export const AUTHORIZATION_CODE_HTML = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MCP Client Authorization</title>
+    <style>${OAUTH_PAGE_SHARED_CSS}</style>
+</head>
+<body class="a8c-oauth-page">
+    <div class="a8c-oauth-wrap">
+    <main class="a8c-oauth-card a8c-oauth-card--center" role="main">
+        <h1 class="a8c-oauth-title">MCP Client Authorization</h1>
+        <div class="a8c-oauth-spinner" id="spinner" aria-hidden="true"></div>
+        <div id="status" class="a8c-oauth-status a8c-oauth-status--loading" role="status">Processing authorization code…</div>
+        <div id="details" class="a8c-oauth-details"></div>
+    </main>
+    </div>
+
+    <script>
+        function displayStatus(message, type = 'loading') {
+            const statusEl = document.getElementById('status');
+            const spinnerEl = document.getElementById('spinner');
+            
+            statusEl.textContent = message;
+            statusEl.className = 'a8c-oauth-status a8c-oauth-status--' + type;
+            
+            if (type !== 'loading') {
+                spinnerEl.style.display = 'none';
+            }
+        }
+
+        function displayDetails(message) {
+            document.getElementById('details').textContent = message;
+        }
+
+        // Handle both OAuth 2.1 authorization code flow and implicit flow
+        const urlParams = new URLSearchParams(window.location.search);
+        const hashParams = new URLSearchParams(window.location.hash.substring(1));
+
+        // Check for authorization code first (OAuth 2.1 flow)
+        if (urlParams.has('code')) {
+            const authData = {
+                code: urlParams.get('code'),
+                state: urlParams.get('state'),
+                // Additional parameters for validation
+                iss: urlParams.get('iss'),
+            };
+
+            // Send authorization code to server for token exchange
+            fetch('/oauth/callback', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(authData)
+            })
+            .then(response => {
+                if (response.ok) {
+                    displayStatus('Authorization successful.', 'success');
+                    displayDetails('You can safely close this window.');
+                } else {
+                    return response.json().then(err => {
+                        throw new Error(err.error || 'Failed to exchange authorization code');
+                    });
+                }
+            })
+            .catch(error => {
+                displayStatus('Error completing authorization', 'error');
+                displayDetails(error.message + '. Please try again.');
+            });
+        } 
+        // Check for access token in URL fragment (implicit flow)
+        else if (hashParams.has('access_token')) {
+            const tokens = {
+                access_token: hashParams.get('access_token'),
+                token_type: hashParams.get('token_type') || 'Bearer',
+                expires_in: hashParams.get('expires_in') ? parseInt(hashParams.get('expires_in')) : 3600,
+                scope: hashParams.get('scope'),
+                state: hashParams.get('state'),
+                obtained_at: Date.now()
+            };
+
+            // Send tokens to server for storage
+            fetch('/oauth/tokens', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(tokens)
+            })
+            .then(response => {
+                if (response.ok) {
+                    displayStatus('Authorization successful.', 'success');
+                    displayDetails('You can safely close this window.');
+                } else {
+                    return response.json().then(err => {
+                        throw new Error(err.error || 'Failed to store access token');
+                    });
+                }
+            })
+            .catch(error => {
+                displayStatus('Error completing authorization', 'error');
+                displayDetails(error.message + '. Please try again.');
+            });
+        } 
+        // Check for errors in query parameters
+        else if (urlParams.has('error')) {
+            const error = urlParams.get('error');
+            const errorDescription = urlParams.get('error_description');
+            displayStatus('Authorization failed', 'error');
+            displayDetails(\`Error: \${error}\${errorDescription ? ' — ' + errorDescription : ''}\`);
+        } 
+        // Check for errors in URL fragment (implicit flow errors)
+        else if (hashParams.has('error')) {
+            const error = hashParams.get('error');
+            const errorDescription = hashParams.get('error_description');
+            displayStatus('Authorization failed', 'error');
+            displayDetails(\`Error: \${error}\${errorDescription ? ' — ' + errorDescription : ''}\`);
+        } 
+        // No authorization code or access token found
+        else {
+            displayStatus('No authorization code or access token received', 'error');
+            displayDetails('Please try the authorization process again.');
+        }
+    </script>
+</body>
+</html>
+`;

--- a/src/lib/persistent-oauth-client-provider.ts
+++ b/src/lib/persistent-oauth-client-provider.ts
@@ -12,7 +12,10 @@ import {
   isTokenValid,
 } from './persistent-auth-config.js';
 import { WPTokens, WPClientInfo, OAuthError, WPOAuthOptions } from './oauth-types.js';
-import { setupWPOAuthCallbackServer } from './oauth-callback-server.js';
+import {
+  setupWPOAuthCallbackServer,
+  formatSiteLabelForOAuthLanding,
+} from './oauth-callback-server.js';
 import { logger } from './utils.js';
 import { CONFIG, getDefaultOAuthScopes, getOAuthCallbackPort } from './config.js';
 
@@ -230,16 +233,29 @@ export class PersistentWPOAuthClientProvider {
       logger.oauth(`Built authorization URL: ${authUrl}`);
       logger.debug(`Callback URL: ${callbackServer.getCallbackUrl()}`, 'OAUTH');
 
-      // Open browser to authorization URL
+      callbackServer.setLandingContext(
+        authUrl,
+        formatSiteLabelForOAuthLanding(this.options.serverUrl)
+      );
+      const urlToOpen = CONFIG.OAUTH_LANDING_PAGE ? callbackServer.getLandingUrl() : authUrl;
+
+      // Open browser (localhost landing first, or authorize URL if OAUTH_LANDING_PAGE=false)
       logger.oauth('Attempting to open browser...');
       try {
-        await open(authUrl);
+        await open(urlToOpen);
         logger.oauth('Browser opened successfully');
       } catch (browserError) {
         logger.error('Failed to open browser automatically', 'OAUTH', browserError);
         logger.info('\n=== MANUAL ACTION REQUIRED ===');
-        logger.info('Please manually open the following URL in your browser:');
-        logger.info(`${authUrl}`);
+        if (CONFIG.OAUTH_LANDING_PAGE) {
+          logger.info('Open this page in your browser (review, then continue to OAuth):');
+          logger.info(`${callbackServer.getLandingUrl()}`);
+          logger.info('Or open the authorization URL directly:');
+          logger.info(`${authUrl}`);
+        } else {
+          logger.info('Please manually open the following URL in your browser:');
+          logger.info(`${authUrl}`);
+        }
         logger.info('===============================\n');
         // Don't throw here, continue waiting for manual authorization
       }

--- a/tests/unit/oauth-landing.test.ts
+++ b/tests/unit/oauth-landing.test.ts
@@ -1,0 +1,20 @@
+/**
+ * OAuth landing page helpers
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { formatSiteLabelForOAuthLanding } from '../../src/lib/oauth-callback-server.js';
+
+describe('formatSiteLabelForOAuthLanding', () => {
+  it('returns host for HTTPS URL with path', () => {
+    expect(formatSiteLabelForOAuthLanding('https://mysite.com/blog')).toBe('mysite.com');
+  });
+
+  it('returns host for URL with port', () => {
+    expect(formatSiteLabelForOAuthLanding('http://localhost:8888')).toBe('localhost:8888');
+  });
+
+  it('returns original string when URL is invalid', () => {
+    expect(formatSiteLabelForOAuthLanding('not-a-valid-url')).toBe('not-a-valid-url');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **localhost OAuth landing page** that opens before the real OAuth authorization redirect. Instead of immediately bouncing the user's browser to the IdP, the proxy first opens a localhost page (`GET /oauth/start` on the callback server) showing **which site is being authorized**. The user reviews it and clicks through to the actual authorization URL.

This reduces the "surprise redirect" / phishing risk of an unattended jump to an external auth server.

The landing page is enabled by default. Set `OAUTH_LANDING_PAGE=false` to restore the previous direct-redirect behavior.

<img width="2302" height="1754" alt="Screenshot 2026-06-12 at 02-44-15 —" src="https://github.com/user-attachments/assets/33c058e7-b4e2-43ba-ac10-03833672e23f" />

<img width="2302" height="1754" alt="Screenshot 2026-06-12 at 02-44-44 —" src="https://github.com/user-attachments/assets/9dacf563-001e-43c4-8e54-a585e62a7a18" />

<img width="2302" height="1754" alt="Screenshot 2026-06-12 at 02-43-58 —" src="https://github.com/user-attachments/assets/8c6428f7-4213-43af-ba84-05ac3f5068ff" />

<img width="2302" height="1754" alt="Screenshot 2026-06-12 at 02-44-29 —" src="https://github.com/user-attachments/assets/6abb73f3-b291-47b8-8f36-99cd54166db5" />

## Testing

- New tests added.

To try it: `npm run dev:oauth-html`, then open the printed URL (default `http://127.0.0.1:8765/`).
