### PR TITLE
fix(config): bump MCP_WORDPRESS_REMOTE_VERSION to 0.3.5

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,7 +4,7 @@ import { selectCallbackPort } from './port-utils.js';
 import { logger } from './utils.js';
 
 // Version constant - update this manually when releasing new versions
-export const MCP_WORDPRESS_REMOTE_VERSION = '0.3.4';
+export const MCP_WORDPRESS_REMOTE_VERSION = '0.3.5';
 
 /**
  * Parse a positive integer from an environment variable, falling back to a


### PR DESCRIPTION
## Summary

- `MCP_WORDPRESS_REMOTE_VERSION` in `src/lib/config.ts` was not bumped when `package.json` was updated to `0.3.5`
- This caused `serverInfo.version` in MCP initialize responses to report `0.3.4` to clients
- Caught during pre-publish release gate testing

## Test plan

- [x] Built and packed tarball locally
- [x] Sent MCP `initialize` over stdin — `serverInfo.version` now reports `0.3.5`
- [x] Broken endpoint fallback still works correctly
- [x] Healthy endpoint (WordPress.com) — `tools/list` returns 24 tools, no stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)