### PR TITLE
chore(license): set copyright holder to Automattic Inc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Your Name
+Copyright (c) 2025 Automattic Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

The MIT `LICENSE` shipped with a scaffolding placeholder on the copyright line:

```
Copyright (c) 2024 Your Name
```

This replaces it with the real holder and corrects the year:

```
Copyright (c) 2025 Automattic Inc.
```

- **Holder:** `Automattic Inc.`, matching the `author` field in `package.json`.
- **Year:** `2025`, the year of the first commit. The placeholder `2024` predated the repo.

This is a one-line fix. The license itself stays MIT. No code, dependencies, or exports change.

Follow-up to #83, which added the `license: "MIT"` field to `package.json` but did not touch the `LICENSE` file.

## Validation

- `git diff` shows a single changed line in `LICENSE`.
- `license` field in `package.json` is unchanged (`MIT`).