### PR TITLE
Add a post-tool-call hook so embedding packages can piggyback on the authenticated request

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -38,3 +38,7 @@ export { setupFetchPolyfill, proxyFetch, getProxyInfo, isFetchAvailable, getFetc
 
 // Export proxy utilities
 export { initializeProxy, isProxyConfigured, getProxyType, getAgentForUrl } from './lib/proxy-utils.js';
+
+// Export tool-call hooks (embedding packages can piggyback on the live session)
+export { registerToolCallHook } from './lib/tool-call-hooks.js';
+export type { ToolCallHook, ToolCallContext } from './lib/tool-call-hooks.js';

--- a/src/lib/request-handler-factory.ts
+++ b/src/lib/request-handler-factory.ts
@@ -4,7 +4,13 @@
  * Creates standardized request handlers to eliminate repetitive code
  */
 
-import { McpError, ErrorCode, CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  McpError,
+  ErrorCode,
+  CallToolResultSchema,
+  ListToolsResultSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { AjvJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/ajv';
 import { logger } from './utils.js';
 import { wpRequest } from './wordpress-api.js';
 import { isAPIError } from './oauth-types.js';
@@ -12,6 +18,8 @@ import { convertAPIErrorToMcpError, apiErrorToMcpError } from './error-utils.js'
 import { prepareRequest, waitForInit, SessionContext } from './session-utils.js';
 import { WPRequestParams } from './mcp-types.js';
 import { runToolCallHooks } from './tool-call-hooks.js';
+
+const jsonSchemaValidator = new AjvJsonSchemaValidator();
 
 /**
  * Configuration for creating a request handler
@@ -57,15 +65,38 @@ export function createRequestHandler(config: HandlerConfig, context: SessionCont
     // Send request to WordPress
     const response = await wpRequest(requestData, context.transportType === 'jsonrpc');
 
+    // Mirror the SDK client's tools/list cache so the hook gate can apply the
+    // same advertised outputSchema validation that callTool() applies after
+    // this handler returns.
+    if (config.method === 'tools/list') {
+      const parsedTools = ListToolsResultSchema.safeParse(response);
+      if (parsedTools.success) {
+        context._toolOutputValidators.clear();
+        for (const tool of parsedTools.data.tools) {
+          if (tool.outputSchema) {
+            context._toolOutputValidators.set(
+              tool.name,
+              jsonSchemaValidator.getValidator(tool.outputSchema)
+            );
+          }
+        }
+      }
+    }
+
     // Let embedding packages piggyback on the live authenticated session after a
     // successful tool call (e.g. usage telemetry). Best-effort; never alters the
     // response the client receives.
     //
     // wpRequest resolving only proves the HTTP exchange succeeded — the SDK
-    // validates CallToolResultSchema after this handler returns, so a malformed
-    // HTTP-200 body would otherwise fire hooks for a call that then fails on
-    // the client. Only fire them for results the client will actually accept.
-    if (config.method === 'tools/call' && CallToolResultSchema.safeParse(response).success) {
+    // validates both CallToolResultSchema and the advertised per-tool
+    // outputSchema after this handler returns. Only fire hooks for results the
+    // client will actually accept.
+    const parsedToolResult = CallToolResultSchema.safeParse(response);
+    if (
+      config.method === 'tools/call' &&
+      parsedToolResult.success &&
+      isAcceptedToolResult((wpParams as any).name ?? '', parsedToolResult.data, context)
+    ) {
       // Hook requests must ride the session's detected transport: prepare them
       // the same way the proxied call was prepared, so a hook works on both
       // JSON-RPC and simple sessions instead of wpRequest's JSON-RPC default.
@@ -76,6 +107,32 @@ export function createRequestHandler(config: HandlerConfig, context: SessionCont
 
     return response;
   };
+}
+
+/** Match the SDK client's post-call validation of advertised structured output. */
+function isAcceptedToolResult(
+  toolName: string,
+  result: { structuredContent?: Record<string, unknown>; isError?: boolean },
+  context: SessionContext
+): boolean {
+  const validator = context._toolOutputValidators.get(toolName);
+  if (!validator) {
+    return true;
+  }
+
+  // The SDK permits an error result without structured content even when the
+  // tool advertises an output schema.
+  if (!result.structuredContent) {
+    return result.isError === true;
+  }
+
+  try {
+    return validator(result.structuredContent).valid;
+  } catch {
+    // A validator failure will also reject in the client. It must not reopen
+    // the proxy response path or dispatch a success hook.
+    return false;
+  }
 }
 
 /**

--- a/src/lib/request-handler-factory.ts
+++ b/src/lib/request-handler-factory.ts
@@ -19,8 +19,6 @@ import { prepareRequest, waitForInit, SessionContext } from './session-utils.js'
 import { WPRequestParams } from './mcp-types.js';
 import { runToolCallHooks } from './tool-call-hooks.js';
 
-const jsonSchemaValidator = new AjvJsonSchemaValidator();
-
 /**
  * Configuration for creating a request handler
  */
@@ -71,15 +69,28 @@ export function createRequestHandler(config: HandlerConfig, context: SessionCont
     if (config.method === 'tools/list') {
       const parsedTools = ListToolsResultSchema.safeParse(response);
       if (parsedTools.success) {
-        context._toolOutputValidators.clear();
+        const nextJsonSchemaValidator = new AjvJsonSchemaValidator();
+        const nextToolOutputValidators = new Map<string, (input: unknown) => { valid: boolean }>();
         for (const tool of parsedTools.data.tools) {
           if (tool.outputSchema) {
-            context._toolOutputValidators.set(
+            // The SDK validator wrapper assumes synchronous AJV validators. An
+            // async schema would return a Promise that is mistaken for a valid
+            // result, then reject outside the tool-call validation try/catch.
+            if (tool.outputSchema.$async === true) {
+              throw new Error(`Async output schemas are not supported for tool ${tool.name}`);
+            }
+
+            nextToolOutputValidators.set(
               tool.name,
-              jsonSchemaValidator.getValidator(tool.outputSchema)
+              nextJsonSchemaValidator.getValidator(tool.outputSchema)
             );
           }
         }
+
+        // Compile the complete list before replacing the live cache. If any
+        // schema fails, the client rejects listTools() and both sides retain
+        // the validators from the last successful response.
+        context._toolOutputValidators = nextToolOutputValidators;
       }
     }
 

--- a/src/lib/request-handler-factory.ts
+++ b/src/lib/request-handler-factory.ts
@@ -4,13 +4,14 @@
  * Creates standardized request handlers to eliminate repetitive code
  */
 
-import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { McpError, ErrorCode, CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import { logger } from './utils.js';
 import { wpRequest } from './wordpress-api.js';
 import { isAPIError } from './oauth-types.js';
 import { convertAPIErrorToMcpError, apiErrorToMcpError } from './error-utils.js';
 import { prepareRequest, waitForInit, SessionContext } from './session-utils.js';
 import { WPRequestParams } from './mcp-types.js';
+import { runToolCallHooks } from './tool-call-hooks.js';
 
 /**
  * Configuration for creating a request handler
@@ -55,6 +56,23 @@ export function createRequestHandler(config: HandlerConfig, context: SessionCont
 
     // Send request to WordPress
     const response = await wpRequest(requestData, context.transportType === 'jsonrpc');
+
+    // Let embedding packages piggyback on the live authenticated session after a
+    // successful tool call (e.g. usage telemetry). Best-effort; never alters the
+    // response the client receives.
+    //
+    // wpRequest resolving only proves the HTTP exchange succeeded — the SDK
+    // validates CallToolResultSchema after this handler returns, so a malformed
+    // HTTP-200 body would otherwise fire hooks for a call that then fails on
+    // the client. Only fire them for results the client will actually accept.
+    if (config.method === 'tools/call' && CallToolResultSchema.safeParse(response).success) {
+      // Hook requests must ride the session's detected transport: prepare them
+      // the same way the proxied call was prepared, so a hook works on both
+      // JSON-RPC and simple sessions instead of wpRequest's JSON-RPC default.
+      const hookWpRequest = (params: WPRequestParams) =>
+        wpRequest(prepareRequest(params, {}, context), context.transportType === 'jsonrpc');
+      runToolCallHooks({ name: (wpParams as any).name ?? '', wpRequest: hookWpRequest });
+    }
 
     return response;
   };

--- a/src/lib/request-handler-factory.ts
+++ b/src/lib/request-handler-factory.ts
@@ -4,13 +4,7 @@
  * Creates standardized request handlers to eliminate repetitive code
  */
 
-import {
-  McpError,
-  ErrorCode,
-  CallToolResultSchema,
-  ListToolsResultSchema,
-} from '@modelcontextprotocol/sdk/types.js';
-import { AjvJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/ajv';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { logger } from './utils.js';
 import { wpRequest } from './wordpress-api.js';
 import { isAPIError } from './oauth-types.js';
@@ -63,87 +57,19 @@ export function createRequestHandler(config: HandlerConfig, context: SessionCont
     // Send request to WordPress
     const response = await wpRequest(requestData, context.transportType === 'jsonrpc');
 
-    // Mirror the SDK client's tools/list cache so the hook gate can apply the
-    // same advertised outputSchema validation that callTool() applies after
-    // this handler returns.
-    if (config.method === 'tools/list') {
-      const parsedTools = ListToolsResultSchema.safeParse(response);
-      if (parsedTools.success) {
-        const nextJsonSchemaValidator = new AjvJsonSchemaValidator();
-        const nextToolOutputValidators = new Map<string, (input: unknown) => { valid: boolean }>();
-        for (const tool of parsedTools.data.tools) {
-          if (tool.outputSchema) {
-            // The SDK validator wrapper assumes synchronous AJV validators. An
-            // async schema would return a Promise that is mistaken for a valid
-            // result, then reject outside the tool-call validation try/catch.
-            if (tool.outputSchema.$async === true) {
-              throw new Error(`Async output schemas are not supported for tool ${tool.name}`);
-            }
-
-            nextToolOutputValidators.set(
-              tool.name,
-              nextJsonSchemaValidator.getValidator(tool.outputSchema)
-            );
-          }
-        }
-
-        // Compile the complete list before replacing the live cache. If any
-        // schema fails, the client rejects listTools() and both sides retain
-        // the validators from the last successful response.
-        context._toolOutputValidators = nextToolOutputValidators;
-      }
-    }
-
-    // Let embedding packages piggyback on the live authenticated session after a
-    // successful tool call (e.g. usage telemetry). Best-effort; never alters the
-    // response the client receives.
-    //
-    // wpRequest resolving only proves the HTTP exchange succeeded — the SDK
-    // validates both CallToolResultSchema and the advertised per-tool
-    // outputSchema after this handler returns. Only fire hooks for results the
-    // client will actually accept.
-    const parsedToolResult = CallToolResultSchema.safeParse(response);
-    if (
-      config.method === 'tools/call' &&
-      parsedToolResult.success &&
-      isAcceptedToolResult((wpParams as any).name ?? '', parsedToolResult.data, context)
-    ) {
+    // A completed tools/call can trigger optional side effects over the same
+    // authenticated session. Result validation remains the MCP client's job.
+    if (config.method === 'tools/call') {
       // Hook requests must ride the session's detected transport: prepare them
       // the same way the proxied call was prepared, so a hook works on both
       // JSON-RPC and simple sessions instead of wpRequest's JSON-RPC default.
       const hookWpRequest = (params: WPRequestParams) =>
         wpRequest(prepareRequest(params, {}, context), context.transportType === 'jsonrpc');
-      runToolCallHooks({ name: (wpParams as any).name ?? '', wpRequest: hookWpRequest });
+      runToolCallHooks({ name: String(wpParams.name ?? ''), wpRequest: hookWpRequest });
     }
 
     return response;
   };
-}
-
-/** Match the SDK client's post-call validation of advertised structured output. */
-function isAcceptedToolResult(
-  toolName: string,
-  result: { structuredContent?: Record<string, unknown>; isError?: boolean },
-  context: SessionContext
-): boolean {
-  const validator = context._toolOutputValidators.get(toolName);
-  if (!validator) {
-    return true;
-  }
-
-  // The SDK permits an error result without structured content even when the
-  // tool advertises an output schema.
-  if (!result.structuredContent) {
-    return result.isError === true;
-  }
-
-  try {
-    return validator(result.structuredContent).valid;
-  } catch {
-    // A validator failure will also reject in the client. It must not reopen
-    // the proxy response path or dispatch a success hook.
-    return false;
-  }
 }
 
 /**

--- a/src/lib/session-utils.ts
+++ b/src/lib/session-utils.ts
@@ -15,6 +15,8 @@ export interface SessionContext {
   sessionId: string | null;
   requestIdCounter: number;
   transportType: TransportType;
+  /** @internal Output validators cached from the latest tools/list response. */
+  _toolOutputValidators: Map<string, (input: unknown) => { valid: boolean }>;
   /** @internal Managed by resolveInit/waitForInit — do not access directly. */
   _init: {
     ready: Promise<void>;
@@ -89,6 +91,7 @@ export function createSessionContext(): SessionContext {
     sessionId: null,
     requestIdCounter: 0,
     transportType: null,
+    _toolOutputValidators: new Map(),
     _init: {
       ready,
       resolve: resolve!,

--- a/src/lib/session-utils.ts
+++ b/src/lib/session-utils.ts
@@ -15,8 +15,6 @@ export interface SessionContext {
   sessionId: string | null;
   requestIdCounter: number;
   transportType: TransportType;
-  /** @internal Output validators cached from the latest tools/list response. */
-  _toolOutputValidators: Map<string, (input: unknown) => { valid: boolean }>;
   /** @internal Managed by resolveInit/waitForInit — do not access directly. */
   _init: {
     ready: Promise<void>;
@@ -91,7 +89,6 @@ export function createSessionContext(): SessionContext {
     sessionId: null,
     requestIdCounter: 0,
     transportType: null,
-    _toolOutputValidators: new Map(),
     _init: {
       ready,
       resolve: resolve!,

--- a/src/lib/tool-call-hooks.ts
+++ b/src/lib/tool-call-hooks.ts
@@ -1,7 +1,7 @@
 /**
  * Tool-call hooks for MCP WordPress Remote.
  *
- * Lets an embedding package observe successful `tools/call` requests and
+ * Lets an embedding package observe completed `tools/call` requests and
  * piggyback on the proxy's live, authenticated session — for example to send
  * usage telemetry — without forking the proxy.
  *
@@ -27,7 +27,7 @@ export interface ToolCallContext {
   wpRequest: (params: WPRequestParams) => Promise<WordPressResponse>;
 }
 
-/** A hook fired after each successful `tools/call`. May be async. */
+/** A hook fired after each completed `tools/call`. May be async. */
 export type ToolCallHook = (context: ToolCallContext) => void | Promise<void>;
 
 const REGISTRY_KEY = Symbol.for('@automattic/mcp-wordpress-remote:tool-call-hooks');
@@ -43,7 +43,7 @@ function getRegistry(): Set<ToolCallHook> {
 }
 
 /**
- * Register a hook fired after each successful `tools/call`. Returns a function
+ * Register a hook fired after each completed `tools/call`. Returns a function
  * that unregisters it.
  */
 export function registerToolCallHook(hook: ToolCallHook): () => void {
@@ -55,38 +55,27 @@ export function registerToolCallHook(hook: ToolCallHook): () => void {
 }
 
 /**
- * Invoke all registered hooks. Best-effort: a hook that throws synchronously
- * or returns a rejecting promise is isolated so it can never break the tool
- * call it rode in on. Failures are logged so a broken hook stays diagnosable.
+ * Invoke all registered hooks after the request path has completed. A hook can
+ * never alter the tool call it rode in on: it runs on a later tick and its
+ * failures are isolated and logged rather than propagated.
  */
 export function runToolCallHooks(context: ToolCallContext): void {
-  // Iterate a snapshot: a hook that unregisters and re-registers itself would
-  // be appended to the live Set and revisited in the same pass, forever.
+  // Snapshot the registry: a hook that unregisters and re-registers itself
+  // would otherwise be revisited forever within this same pass.
   const hooks = [...getRegistry()];
+  if (hooks.length === 0) return;
 
-  // Invoke hooks on the next event-loop turn. Calling `hook(context)` inside
-  // Promise.resolve still runs all synchronous (and pre-first-await) work on
-  // the tool-call response path, so a slow hook could delay the client.
   setImmediate(() => {
     for (const hook of hooks) {
-      try {
-        Promise.resolve(hook(context)).catch(error => {
-          logHookFailure(error);
-        });
-      } catch (error) {
-        logHookFailure(error);
-      }
+      void Promise.resolve()
+        .then(() => hook(context))
+        .catch(error => {
+          const message = error instanceof Error ? error.message : String(error);
+          logger.error(`Tool-call hook failed: ${message}`, 'HOOKS');
+        })
+        // Logging can itself fail (e.g. an unwritable LOG_FILE); never let that
+        // reopen the failure path as an unhandled rejection.
+        .catch(() => {});
     }
   });
-}
-
-/** A hook must never break the request path — log the failure and move on. */
-function logHookFailure(error: unknown): void {
-  try {
-    const message = error instanceof Error ? error.message : String(error);
-    logger.error(`Tool-call hook failed: ${message}`, 'HOOKS');
-  } catch {
-    // Logging can itself fail (for example, an unwritable LOG_FILE). Hook
-    // diagnostics remain best-effort and must never reopen the failure path.
-  }
 }

--- a/src/lib/tool-call-hooks.ts
+++ b/src/lib/tool-call-hooks.ts
@@ -1,0 +1,92 @@
+/**
+ * Tool-call hooks for MCP WordPress Remote.
+ *
+ * Lets an embedding package observe successful `tools/call` requests and
+ * piggyback on the proxy's live, authenticated session — for example to send
+ * usage telemetry — without forking the proxy.
+ *
+ * The registry lives on a global symbol so it is a single instance even when a
+ * consumer registers through the `/lib` bundle while the handlers run in the
+ * separate `proxy` bundle.
+ */
+
+import { logger } from './utils.js';
+import type { WordPressResponse } from './types.js';
+import type { WPRequestParams } from './mcp-types.js';
+
+/** Context passed to each hook after a tool call completes. */
+export interface ToolCallContext {
+  /** Name of the tool the client just called. */
+  name: string;
+  /**
+   * Dispatch an additional request over the proxy's live, authenticated
+   * session. The request is prepared for the session's detected transport
+   * (JSON-RPC envelope or simple format) before it is sent, e.g.
+   * `wpRequest({ method: 'tools/call', name, arguments })`.
+   */
+  wpRequest: (params: WPRequestParams) => Promise<WordPressResponse>;
+}
+
+/** A hook fired after each successful `tools/call`. May be async. */
+export type ToolCallHook = (context: ToolCallContext) => void | Promise<void>;
+
+const REGISTRY_KEY = Symbol.for('@automattic/mcp-wordpress-remote:tool-call-hooks');
+
+function getRegistry(): Set<ToolCallHook> {
+  const globalObject = globalThis as Record<PropertyKey, unknown>;
+  let registry = globalObject[REGISTRY_KEY] as Set<ToolCallHook> | undefined;
+  if (!registry) {
+    registry = new Set<ToolCallHook>();
+    globalObject[REGISTRY_KEY] = registry;
+  }
+  return registry;
+}
+
+/**
+ * Register a hook fired after each successful `tools/call`. Returns a function
+ * that unregisters it.
+ */
+export function registerToolCallHook(hook: ToolCallHook): () => void {
+  const registry = getRegistry();
+  registry.add(hook);
+  return () => {
+    registry.delete(hook);
+  };
+}
+
+/**
+ * Invoke all registered hooks. Best-effort: a hook that throws synchronously
+ * or returns a rejecting promise is isolated so it can never break the tool
+ * call it rode in on. Failures are logged so a broken hook stays diagnosable.
+ */
+export function runToolCallHooks(context: ToolCallContext): void {
+  // Iterate a snapshot: a hook that unregisters and re-registers itself would
+  // be appended to the live Set and revisited in the same pass, forever.
+  const hooks = [...getRegistry()];
+
+  // Invoke hooks on the next event-loop turn. Calling `hook(context)` inside
+  // Promise.resolve still runs all synchronous (and pre-first-await) work on
+  // the tool-call response path, so a slow hook could delay the client.
+  setImmediate(() => {
+    for (const hook of hooks) {
+      try {
+        Promise.resolve(hook(context)).catch(error => {
+          logHookFailure(error);
+        });
+      } catch (error) {
+        logHookFailure(error);
+      }
+    }
+  });
+}
+
+/** A hook must never break the request path — log the failure and move on. */
+function logHookFailure(error: unknown): void {
+  try {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(`Tool-call hook failed: ${message}`, 'HOOKS');
+  } catch {
+    // Logging can itself fail (for example, an unwritable LOG_FILE). Hook
+    // diagnostics remain best-effort and must never reopen the failure path.
+  }
+}

--- a/tests/unit/tool-call-hooks.test.ts
+++ b/tests/unit/tool-call-hooks.test.ts
@@ -249,6 +249,163 @@ describe('tool-call hooks', () => {
     expect(calls).toEqual(['called']);
   });
 
+  it('rejects async output schemas before caching their validators', async () => {
+    nock('https://test-wp.example.com')
+      .post('/?rest_route=/wp/v2/wpmcp')
+      .reply(200, {
+        tools: [
+          {
+            name: 'async-tool',
+            inputSchema: { type: 'object' },
+            outputSchema: {
+              $async: true,
+              type: 'object',
+              properties: { count: { type: 'number' } },
+            },
+          },
+        ],
+      });
+
+    context.transportType = 'jsonrpc';
+    resolveInit(context, false);
+    const listTools = createRequestHandler(HANDLER_CONFIGS.listTools, context);
+
+    await expect(listTools({ id: 1, params: {} })).rejects.toThrow(
+      'Async output schemas are not supported for tool async-tool'
+    );
+    expect(context._toolOutputValidators.size).toBe(0);
+  });
+
+  it('keeps the previous validator cache when a tools/list refresh fails', async () => {
+    nock('https://test-wp.example.com')
+      .post('/?rest_route=/wp/v2/wpmcp')
+      .reply(200, {
+        tools: [
+          {
+            name: 'my-tool',
+            inputSchema: { type: 'object' },
+            outputSchema: {
+              type: 'object',
+              properties: { count: { type: 'number' } },
+              required: ['count'],
+            },
+          },
+        ],
+      })
+      .post('/?rest_route=/wp/v2/wpmcp')
+      .reply(200, {
+        tools: [
+          {
+            name: 'my-tool',
+            inputSchema: { type: 'object' },
+            outputSchema: {
+              type: 'object',
+              properties: { count: { type: 'string' } },
+              required: ['count'],
+            },
+          },
+          {
+            name: 'invalid-tool',
+            inputSchema: { type: 'object' },
+            outputSchema: {
+              type: 'object',
+              properties: { value: { type: 'not-a-json-schema-type' } },
+            },
+          },
+        ],
+      })
+      .post('/?rest_route=/wp/v2/wpmcp')
+      .reply(200, {
+        content: [{ type: 'text', text: 'ok' }],
+        structuredContent: { count: 'valid-only-for-the-failed-refresh' },
+      });
+
+    const calls: any[] = [];
+    addHook(() => {
+      calls.push('called');
+    });
+
+    context.transportType = 'jsonrpc';
+    resolveInit(context, false);
+    const listTools = createRequestHandler(HANDLER_CONFIGS.listTools, context);
+    const callTool = createRequestHandler(HANDLER_CONFIGS.callTool, context);
+
+    await listTools({ id: 1, params: {} });
+    const previousValidators = context._toolOutputValidators;
+    await expect(listTools({ id: 2, params: {} })).rejects.toThrow();
+    expect(context._toolOutputValidators).toBe(previousValidators);
+
+    await callTool({ id: 3, params: { name: 'my-tool' } });
+    await flush();
+
+    expect(calls).toEqual([]);
+  });
+
+  it('does not reuse a schema compiled during a failed tools/list refresh', async () => {
+    const schemaId = 'https://example.com/schemas/my-tool-output';
+    nock('https://test-wp.example.com')
+      .post('/?rest_route=/wp/v2/wpmcp')
+      .reply(200, {
+        tools: [
+          {
+            name: 'my-tool',
+            inputSchema: { type: 'object' },
+            outputSchema: {
+              $id: schemaId,
+              type: 'object',
+              properties: { count: { type: 'string' } },
+              required: ['count'],
+            },
+          },
+          {
+            name: 'invalid-tool',
+            inputSchema: { type: 'object' },
+            outputSchema: {
+              type: 'object',
+              properties: { value: { type: 'not-a-json-schema-type' } },
+            },
+          },
+        ],
+      })
+      .post('/?rest_route=/wp/v2/wpmcp')
+      .reply(200, {
+        tools: [
+          {
+            name: 'my-tool',
+            inputSchema: { type: 'object' },
+            outputSchema: {
+              $id: schemaId,
+              type: 'object',
+              properties: { count: { type: 'number' } },
+              required: ['count'],
+            },
+          },
+        ],
+      })
+      .post('/?rest_route=/wp/v2/wpmcp')
+      .reply(200, {
+        content: [{ type: 'text', text: 'ok' }],
+        structuredContent: { count: 1 },
+      });
+
+    const calls: any[] = [];
+    addHook(() => {
+      calls.push('called');
+    });
+
+    context.transportType = 'jsonrpc';
+    resolveInit(context, false);
+    const listTools = createRequestHandler(HANDLER_CONFIGS.listTools, context);
+    const callTool = createRequestHandler(HANDLER_CONFIGS.callTool, context);
+
+    await expect(listTools({ id: 1, params: {} })).rejects.toThrow();
+    await listTools({ id: 2, params: {} });
+    await callTool({ id: 3, params: { name: 'my-tool' } });
+    await flush();
+
+    expect(calls).toEqual(['called']);
+  });
+
   it('defers hook work until after the tool-call handler resolves', async () => {
     mockToolCall();
     const calls: string[] = [];

--- a/tests/unit/tool-call-hooks.test.ts
+++ b/tests/unit/tool-call-hooks.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Tests for post-tool-call hooks (registerToolCallHook / runToolCallHooks).
+ *
+ * Covers the PR #92 review requirements:
+ * - hooks fire only after a successful tools/call
+ * - hooks do not fire for a malformed (schema-invalid) tool result
+ * - hook work is deferred until after the tool-call handler resolves
+ * - a synchronously throwing hook never affects the client response
+ * - an async (rejecting) hook never becomes an unhandled rejection
+ * - hook failures are logged, not silently swallowed
+ * - a logging failure cannot reopen either hook failure path
+ * - unregistration stops a hook from firing
+ * - a hook that unregisters and re-registers itself cannot loop the pass
+ * - the hook's wpRequest dispatches with the session's detected transport
+ *   (simple format on simple sessions, JSON-RPC envelope on jsonrpc sessions)
+ */
+
+import { jest } from '@jest/globals';
+import nock from 'nock';
+
+describe('tool-call hooks', () => {
+  let createSessionContext: any;
+  let resolveInit: any;
+  let createRequestHandler: any;
+  let HANDLER_CONFIGS: any;
+  let registerToolCallHook: any;
+  let logger: any;
+  let context: any;
+  let unregisterFns: Array<() => void>;
+
+  beforeAll(async () => {
+    // Set env BEFORE modules are imported so CONFIG caches the right values
+    process.env.WP_API_URL = 'https://test-wp.example.com';
+    process.env.JWT_TOKEN = 'test-jwt-token-for-hook-tests';
+    process.env.NODE_ENV = 'test';
+
+    jest.resetModules();
+
+    const sessionMod = await import('../../src/lib/session-utils.js');
+    createSessionContext = sessionMod.createSessionContext;
+    resolveInit = sessionMod.resolveInit;
+
+    const factoryMod = await import('../../src/lib/request-handler-factory.js');
+    createRequestHandler = factoryMod.createRequestHandler;
+    HANDLER_CONFIGS = factoryMod.HANDLER_CONFIGS;
+
+    const hooksMod = await import('../../src/lib/tool-call-hooks.js');
+    registerToolCallHook = hooksMod.registerToolCallHook;
+
+    const utilsMod = await import('../../src/lib/utils.js');
+    logger = utilsMod.logger;
+  });
+
+  afterAll(() => {
+    delete process.env.JWT_TOKEN;
+    nock.cleanAll();
+  });
+
+  beforeEach(() => {
+    context = createSessionContext();
+    unregisterFns = [];
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    // The registry is global — always clean up hooks so tests stay isolated
+    for (const unregister of unregisterFns) {
+      unregister();
+    }
+  });
+
+  /** Register a hook and track it for cleanup. */
+  function addHook(hook: any): () => void {
+    const unregister = registerToolCallHook(hook);
+    unregisterFns.push(unregister);
+    return unregister;
+  }
+
+  /** Prepare a ready session and a callTool handler. */
+  function readyHandler(transportType: 'jsonrpc' | 'simple') {
+    context.transportType = transportType;
+    resolveInit(context, false);
+    return createRequestHandler(HANDLER_CONFIGS.callTool, context);
+  }
+
+  function mockToolCall(times = 1) {
+    const bodies: any[] = [];
+    nock('https://test-wp.example.com')
+      .post('/?rest_route=/wp/v2/wpmcp', (body: any) => {
+        bodies.push(body);
+        return true;
+      })
+      .times(times)
+      .reply(200, { content: [{ type: 'text', text: 'ok' }] });
+    return bodies;
+  }
+
+  /** Flush microtasks and pending macrotasks so fire-and-forget hooks settle. */
+  async function flush() {
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+  }
+
+  it('runs hooks after a successful tools/call with the tool name', async () => {
+    mockToolCall();
+    const calls: any[] = [];
+    addHook((hookContext: any) => {
+      calls.push(hookContext.name);
+    });
+
+    const handler = readyHandler('jsonrpc');
+    await handler({ id: 1, params: { name: 'my-tool', arguments: { a: 1 } } });
+    await flush();
+
+    expect(calls).toEqual(['my-tool']);
+  });
+
+  it('does not run hooks for non-tools/call methods', async () => {
+    nock('https://test-wp.example.com').post('/?rest_route=/wp/v2/wpmcp').reply(200, { tools: [] });
+    const calls: any[] = [];
+    addHook(() => {
+      calls.push('called');
+    });
+
+    context.transportType = 'jsonrpc';
+    resolveInit(context, false);
+    const handler = createRequestHandler(HANDLER_CONFIGS.listTools, context);
+    await handler({ id: 1, params: {} });
+    await flush();
+
+    expect(calls).toEqual([]);
+  });
+
+  it('does not run hooks when the tool call fails', async () => {
+    nock('https://test-wp.example.com')
+      .post('/?rest_route=/wp/v2/wpmcp')
+      .replyWithError(new Error('boom'));
+    const calls: any[] = [];
+    addHook(() => {
+      calls.push('called');
+    });
+
+    const handler = readyHandler('jsonrpc');
+    await expect(handler({ id: 1, params: { name: 'my-tool' } })).rejects.toBeDefined();
+    await flush();
+
+    expect(calls).toEqual([]);
+  });
+
+  it('does not run hooks when the tool result is malformed', async () => {
+    // HTTP 200, but not a valid CallToolResult — the SDK will reject this
+    // after the handler returns, so the call fails for the client and hooks
+    // must not observe it as a success.
+    nock('https://test-wp.example.com')
+      .post('/?rest_route=/wp/v2/wpmcp')
+      .reply(200, { content: 'not-an-array' });
+    const calls: any[] = [];
+    addHook(() => {
+      calls.push('called');
+    });
+
+    const handler = readyHandler('jsonrpc');
+    await handler({ id: 1, params: { name: 'my-tool' } });
+    await flush();
+
+    expect(calls).toEqual([]);
+  });
+
+  it('defers hook work until after the tool-call handler resolves', async () => {
+    mockToolCall();
+    const calls: string[] = [];
+    addHook(() => {
+      calls.push('called');
+    });
+
+    const handler = readyHandler('jsonrpc');
+    const response = await handler({ id: 1, params: { name: 'my-tool' } });
+
+    expect(response).toEqual({ content: [{ type: 'text', text: 'ok' }] });
+    expect(calls).toEqual([]);
+
+    await flush();
+    expect(calls).toEqual(['called']);
+  });
+
+  it('a synchronously throwing hook does not affect the client response', async () => {
+    mockToolCall();
+    addHook(() => {
+      throw new Error('sync hook failure');
+    });
+    const calls: any[] = [];
+    addHook((hookContext: any) => {
+      calls.push(hookContext.name);
+    });
+
+    const handler = readyHandler('jsonrpc');
+    const response = await handler({ id: 1, params: { name: 'my-tool' } });
+    await flush();
+
+    expect(response).toEqual({ content: [{ type: 'text', text: 'ok' }] });
+    // Other hooks still ran despite the throwing one
+    expect(calls).toEqual(['my-tool']);
+  });
+
+  it('an async rejecting hook is consumed, not an unhandled rejection', async () => {
+    mockToolCall();
+    addHook(async () => {
+      throw new Error('async hook failure');
+    });
+
+    const unhandled: unknown[] = [];
+    const onRejection = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', onRejection);
+
+    try {
+      const handler = readyHandler('jsonrpc');
+      const response = await handler({ id: 1, params: { name: 'my-tool' } });
+      await flush();
+
+      expect(response).toEqual({ content: [{ type: 'text', text: 'ok' }] });
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onRejection);
+    }
+  });
+
+  it('logs a failing hook instead of silently swallowing it', async () => {
+    mockToolCall();
+    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+    try {
+      addHook(() => {
+        throw new Error('sync hook failure');
+      });
+      addHook(async () => {
+        throw new Error('async hook failure');
+      });
+
+      const handler = readyHandler('jsonrpc');
+      await handler({ id: 1, params: { name: 'my-tool' } });
+      await flush();
+
+      const messages = errorSpy.mock.calls.map((call: any[]) => call[0]);
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('sync hook failure'),
+          expect.stringContaining('async hook failure'),
+        ])
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('a logging failure cannot reopen synchronous or asynchronous hook failures', async () => {
+    mockToolCall();
+    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {
+      throw new Error('logger failure');
+    });
+    const unhandled: unknown[] = [];
+    const onRejection = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', onRejection);
+
+    try {
+      addHook(() => {
+        throw new Error('sync hook failure');
+      });
+      addHook(async () => {
+        throw new Error('async hook failure');
+      });
+
+      const handler = readyHandler('jsonrpc');
+      const response = await handler({ id: 1, params: { name: 'my-tool' } });
+      await flush();
+
+      expect(response).toEqual({ content: [{ type: 'text', text: 'ok' }] });
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onRejection);
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('an unregistered hook no longer fires', async () => {
+    mockToolCall(2);
+    const calls: any[] = [];
+    const unregister = addHook(() => {
+      calls.push('called');
+    });
+
+    const handler = readyHandler('jsonrpc');
+    await handler({ id: 1, params: { name: 'my-tool' } });
+    await flush();
+    expect(calls).toHaveLength(1);
+
+    unregister();
+    await handler({ id: 2, params: { name: 'my-tool' } });
+    await flush();
+    expect(calls).toHaveLength(1);
+  });
+
+  it('a hook that unregisters and re-registers itself runs once per pass', async () => {
+    // Regression: iterating the live Set would re-visit a hook the pass
+    // re-appended, looping forever and never returning the tool call.
+    mockToolCall(2);
+    let calls = 0;
+    let unregister: () => void;
+    const hook = () => {
+      calls++;
+      unregister();
+      unregister = addHook(hook);
+    };
+    unregister = addHook(hook);
+
+    const handler = readyHandler('jsonrpc');
+    await handler({ id: 1, params: { name: 'my-tool' } });
+    await flush();
+    expect(calls).toBe(1);
+
+    // The re-registered hook still fires on the next pass
+    await handler({ id: 2, params: { name: 'my-tool' } });
+    await flush();
+    expect(calls).toBe(2);
+  });
+
+  it('hook wpRequest sends simple format on a simple-transport session', async () => {
+    const bodies = mockToolCall(2);
+    let hookDispatched: (value?: unknown) => void;
+    const dispatched = new Promise(resolve => {
+      hookDispatched = resolve;
+    });
+    addHook(async (hookContext: any) => {
+      await hookContext.wpRequest({
+        method: 'tools/call',
+        name: 'telemetry-tool',
+        arguments: { event: 'test' },
+      });
+      hookDispatched();
+    });
+
+    const handler = readyHandler('simple');
+    await handler({ id: 1, params: { name: 'my-tool' } });
+    await dispatched;
+
+    expect(bodies).toHaveLength(2);
+    // The hook's request must NOT carry a JSON-RPC envelope on a simple session
+    expect(bodies[1]).not.toHaveProperty('jsonrpc');
+    expect(bodies[1]).toMatchObject({ method: 'tools/call', name: 'telemetry-tool' });
+  });
+
+  it('hook wpRequest sends a JSON-RPC envelope on a jsonrpc session', async () => {
+    const bodies = mockToolCall(2);
+    let hookDispatched: (value?: unknown) => void;
+    const dispatched = new Promise(resolve => {
+      hookDispatched = resolve;
+    });
+    addHook(async (hookContext: any) => {
+      await hookContext.wpRequest({
+        method: 'tools/call',
+        name: 'telemetry-tool',
+        arguments: { event: 'test' },
+      });
+      hookDispatched();
+    });
+
+    const handler = readyHandler('jsonrpc');
+    await handler({ id: 1, params: { name: 'my-tool' } });
+    await dispatched;
+
+    expect(bodies).toHaveLength(2);
+    expect(bodies[1]).toHaveProperty('jsonrpc', '2.0');
+    expect(bodies[1]).toHaveProperty('method', 'tools/call');
+    expect(bodies[1].params).toMatchObject({ name: 'telemetry-tool' });
+  });
+});

--- a/tests/unit/tool-call-hooks.test.ts
+++ b/tests/unit/tool-call-hooks.test.ts
@@ -4,6 +4,7 @@
  * Covers the PR #92 review requirements:
  * - hooks fire only after a successful tools/call
  * - hooks do not fire for a malformed (schema-invalid) tool result
+ * - hooks do not fire when advertised structured output is missing or invalid
  * - hook work is deferred until after the tool-call handler resolves
  * - a synchronously throwing hook never affects the client response
  * - an async (rejecting) hook never becomes an unhandled rejection
@@ -164,6 +165,88 @@ describe('tool-call hooks', () => {
     await flush();
 
     expect(calls).toEqual([]);
+  });
+
+  it.each([
+    ['missing', { content: [{ type: 'text', text: 'ok' }] }],
+    [
+      'invalid',
+      {
+        content: [{ type: 'text', text: 'ok' }],
+        structuredContent: { count: 'not-a-number' },
+      },
+    ],
+  ])('does not run hooks when advertised structured output is %s', async (_case, toolResult) => {
+    nock('https://test-wp.example.com')
+      .post('/?rest_route=/wp/v2/wpmcp')
+      .reply(200, {
+        tools: [
+          {
+            name: 'my-tool',
+            inputSchema: { type: 'object' },
+            outputSchema: {
+              type: 'object',
+              properties: { count: { type: 'number' } },
+              required: ['count'],
+            },
+          },
+        ],
+      })
+      .post('/?rest_route=/wp/v2/wpmcp')
+      .reply(200, toolResult);
+
+    const calls: any[] = [];
+    addHook(() => {
+      calls.push('called');
+    });
+
+    context.transportType = 'jsonrpc';
+    resolveInit(context, false);
+    const listTools = createRequestHandler(HANDLER_CONFIGS.listTools, context);
+    const callTool = createRequestHandler(HANDLER_CONFIGS.callTool, context);
+    await listTools({ id: 1, params: {} });
+    await callTool({ id: 2, params: { name: 'my-tool' } });
+    await flush();
+
+    expect(calls).toEqual([]);
+  });
+
+  it('runs hooks when structured output matches the advertised schema', async () => {
+    nock('https://test-wp.example.com')
+      .post('/?rest_route=/wp/v2/wpmcp')
+      .reply(200, {
+        tools: [
+          {
+            name: 'my-tool',
+            inputSchema: { type: 'object' },
+            outputSchema: {
+              type: 'object',
+              properties: { count: { type: 'number' } },
+              required: ['count'],
+            },
+          },
+        ],
+      })
+      .post('/?rest_route=/wp/v2/wpmcp')
+      .reply(200, {
+        content: [{ type: 'text', text: 'ok' }],
+        structuredContent: { count: 1 },
+      });
+
+    const calls: any[] = [];
+    addHook(() => {
+      calls.push('called');
+    });
+
+    context.transportType = 'jsonrpc';
+    resolveInit(context, false);
+    const listTools = createRequestHandler(HANDLER_CONFIGS.listTools, context);
+    const callTool = createRequestHandler(HANDLER_CONFIGS.callTool, context);
+    await listTools({ id: 1, params: {} });
+    await callTool({ id: 2, params: { name: 'my-tool' } });
+    await flush();
+
+    expect(calls).toEqual(['called']);
   });
 
   it('defers hook work until after the tool-call handler resolves', async () => {

--- a/tests/unit/tool-call-hooks.test.ts
+++ b/tests/unit/tool-call-hooks.test.ts
@@ -1,21 +1,3 @@
-/**
- * Tests for post-tool-call hooks (registerToolCallHook / runToolCallHooks).
- *
- * Covers the PR #92 review requirements:
- * - hooks fire only after a successful tools/call
- * - hooks do not fire for a malformed (schema-invalid) tool result
- * - hooks do not fire when advertised structured output is missing or invalid
- * - hook work is deferred until after the tool-call handler resolves
- * - a synchronously throwing hook never affects the client response
- * - an async (rejecting) hook never becomes an unhandled rejection
- * - hook failures are logged, not silently swallowed
- * - a logging failure cannot reopen either hook failure path
- * - unregistration stops a hook from firing
- * - a hook that unregisters and re-registers itself cannot loop the pass
- * - the hook's wpRequest dispatches with the session's detected transport
- *   (simple format on simple sessions, JSON-RPC envelope on jsonrpc sessions)
- */
-
 import { jest } from '@jest/globals';
 import nock from 'nock';
 
@@ -25,31 +7,26 @@ describe('tool-call hooks', () => {
   let createRequestHandler: any;
   let HANDLER_CONFIGS: any;
   let registerToolCallHook: any;
-  let logger: any;
   let context: any;
-  let unregisterFns: Array<() => void>;
+  let unregisterHooks: Array<() => void>;
 
   beforeAll(async () => {
-    // Set env BEFORE modules are imported so CONFIG caches the right values
     process.env.WP_API_URL = 'https://test-wp.example.com';
     process.env.JWT_TOKEN = 'test-jwt-token-for-hook-tests';
     process.env.NODE_ENV = 'test';
 
     jest.resetModules();
 
-    const sessionMod = await import('../../src/lib/session-utils.js');
-    createSessionContext = sessionMod.createSessionContext;
-    resolveInit = sessionMod.resolveInit;
+    const sessionModule = await import('../../src/lib/session-utils.js');
+    createSessionContext = sessionModule.createSessionContext;
+    resolveInit = sessionModule.resolveInit;
 
-    const factoryMod = await import('../../src/lib/request-handler-factory.js');
-    createRequestHandler = factoryMod.createRequestHandler;
-    HANDLER_CONFIGS = factoryMod.HANDLER_CONFIGS;
+    const handlerModule = await import('../../src/lib/request-handler-factory.js');
+    createRequestHandler = handlerModule.createRequestHandler;
+    HANDLER_CONFIGS = handlerModule.HANDLER_CONFIGS;
 
-    const hooksMod = await import('../../src/lib/tool-call-hooks.js');
-    registerToolCallHook = hooksMod.registerToolCallHook;
-
-    const utilsMod = await import('../../src/lib/utils.js');
-    logger = utilsMod.logger;
+    const hooksModule = await import('../../src/lib/tool-call-hooks.js');
+    registerToolCallHook = hooksModule.registerToolCallHook;
   });
 
   afterAll(() => {
@@ -59,32 +36,29 @@ describe('tool-call hooks', () => {
 
   beforeEach(() => {
     context = createSessionContext();
-    unregisterFns = [];
+    unregisterHooks = [];
     nock.cleanAll();
   });
 
   afterEach(() => {
-    // The registry is global — always clean up hooks so tests stay isolated
-    for (const unregister of unregisterFns) {
+    for (const unregister of unregisterHooks) {
       unregister();
     }
   });
 
-  /** Register a hook and track it for cleanup. */
   function addHook(hook: any): () => void {
     const unregister = registerToolCallHook(hook);
-    unregisterFns.push(unregister);
+    unregisterHooks.push(unregister);
     return unregister;
   }
 
-  /** Prepare a ready session and a callTool handler. */
   function readyHandler(transportType: 'jsonrpc' | 'simple') {
     context.transportType = transportType;
     resolveInit(context, false);
     return createRequestHandler(HANDLER_CONFIGS.callTool, context);
   }
 
-  function mockToolCall(times = 1) {
+  function mockToolCalls(times = 1, response: any = { content: [] }) {
     const bodies: any[] = [];
     nock('https://test-wp.example.com')
       .post('/?rest_route=/wp/v2/wpmcp', (body: any) => {
@@ -92,528 +66,148 @@ describe('tool-call hooks', () => {
         return true;
       })
       .times(times)
-      .reply(200, { content: [{ type: 'text', text: 'ok' }] });
+      .reply(200, response);
     return bodies;
   }
 
-  /** Flush microtasks and pending macrotasks so fire-and-forget hooks settle. */
-  async function flush() {
-    await new Promise(resolve => setImmediate(resolve));
-    await new Promise(resolve => setImmediate(resolve));
+  async function flushHooks() {
+    await new Promise<void>(resolve => setImmediate(resolve));
   }
 
-  it('runs hooks after a successful tools/call with the tool name', async () => {
-    mockToolCall();
-    const calls: any[] = [];
-    addHook((hookContext: any) => {
-      calls.push(hookContext.name);
+  it('runs hooks after a completed tools/call', async () => {
+    mockToolCalls();
+    const calls: string[] = [];
+    addHook(({ name }: { name: string }) => calls.push(name));
+
+    const response = await readyHandler('jsonrpc')({
+      id: 1,
+      params: { name: 'my-tool', arguments: { value: 1 } },
     });
 
-    const handler = readyHandler('jsonrpc');
-    await handler({ id: 1, params: { name: 'my-tool', arguments: { a: 1 } } });
-    await flush();
+    expect(response).toEqual({ content: [] });
+    expect(calls).toEqual([]);
 
+    await flushHooks();
     expect(calls).toEqual(['my-tool']);
   });
 
-  it('does not run hooks for non-tools/call methods', async () => {
+  it('does not interpret the WordPress response before running hooks', async () => {
+    const response = { content: 'validation belongs to the MCP client' };
+    mockToolCalls(1, response);
+    const calls: string[] = [];
+    addHook(() => calls.push('called'));
+
+    await expect(readyHandler('jsonrpc')({ id: 1, params: { name: 'my-tool' } })).resolves.toEqual(
+      response
+    );
+    await flushHooks();
+
+    expect(calls).toEqual(['called']);
+  });
+
+  it('does not run hooks for other methods', async () => {
     nock('https://test-wp.example.com').post('/?rest_route=/wp/v2/wpmcp').reply(200, { tools: [] });
-    const calls: any[] = [];
-    addHook(() => {
-      calls.push('called');
-    });
+    const calls: string[] = [];
+    addHook(() => calls.push('called'));
 
     context.transportType = 'jsonrpc';
     resolveInit(context, false);
-    const handler = createRequestHandler(HANDLER_CONFIGS.listTools, context);
-    await handler({ id: 1, params: {} });
-    await flush();
+    const listTools = createRequestHandler(HANDLER_CONFIGS.listTools, context);
+    await listTools({ id: 1, params: {} });
+    await flushHooks();
 
     expect(calls).toEqual([]);
   });
 
-  it('does not run hooks when the tool call fails', async () => {
+  it('does not run hooks when the WordPress request fails', async () => {
     nock('https://test-wp.example.com')
       .post('/?rest_route=/wp/v2/wpmcp')
       .replyWithError(new Error('boom'));
-    const calls: any[] = [];
-    addHook(() => {
-      calls.push('called');
-    });
+    const calls: string[] = [];
+    addHook(() => calls.push('called'));
 
-    const handler = readyHandler('jsonrpc');
-    await expect(handler({ id: 1, params: { name: 'my-tool' } })).rejects.toBeDefined();
-    await flush();
+    await expect(
+      readyHandler('jsonrpc')({ id: 1, params: { name: 'my-tool' } })
+    ).rejects.toBeDefined();
+    await flushHooks();
 
     expect(calls).toEqual([]);
   });
 
-  it('does not run hooks when the tool result is malformed', async () => {
-    // HTTP 200, but not a valid CallToolResult — the SDK will reject this
-    // after the handler returns, so the call fails for the client and hooks
-    // must not observe it as a success.
-    nock('https://test-wp.example.com')
-      .post('/?rest_route=/wp/v2/wpmcp')
-      .reply(200, { content: 'not-an-array' });
-    const calls: any[] = [];
+  it('isolates synchronous throws and asynchronous rejections', async () => {
+    mockToolCalls();
     addHook(() => {
-      calls.push('called');
+      throw new Error('sync failure');
     });
+    addHook(async () => {
+      throw new Error('async failure');
+    });
+    const calls: string[] = [];
+    addHook(() => calls.push('called'));
 
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      await expect(
+        readyHandler('jsonrpc')({ id: 1, params: { name: 'my-tool' } })
+      ).resolves.toEqual({ content: [] });
+      await flushHooks();
+
+      expect(calls).toEqual(['called']);
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  it('stops calling an unregistered hook', async () => {
+    mockToolCalls(2);
+    const calls: string[] = [];
+    const unregister = addHook(() => calls.push('called'));
     const handler = readyHandler('jsonrpc');
-    await handler({ id: 1, params: { name: 'my-tool' } });
-    await flush();
 
-    expect(calls).toEqual([]);
+    await handler({ id: 1, params: { name: 'my-tool' } });
+    await flushHooks();
+    unregister();
+    await handler({ id: 2, params: { name: 'my-tool' } });
+    await flushHooks();
+
+    expect(calls).toEqual(['called']);
   });
 
   it.each([
-    ['missing', { content: [{ type: 'text', text: 'ok' }] }],
-    [
-      'invalid',
-      {
-        content: [{ type: 'text', text: 'ok' }],
-        structuredContent: { count: 'not-a-number' },
-      },
-    ],
-  ])('does not run hooks when advertised structured output is %s', async (_case, toolResult) => {
-    nock('https://test-wp.example.com')
-      .post('/?rest_route=/wp/v2/wpmcp')
-      .reply(200, {
-        tools: [
-          {
-            name: 'my-tool',
-            inputSchema: { type: 'object' },
-            outputSchema: {
-              type: 'object',
-              properties: { count: { type: 'number' } },
-              required: ['count'],
-            },
-          },
-        ],
-      })
-      .post('/?rest_route=/wp/v2/wpmcp')
-      .reply(200, toolResult);
-
-    const calls: any[] = [];
-    addHook(() => {
-      calls.push('called');
+    ['simple', false],
+    ['jsonrpc', true],
+  ] as const)('binds hook requests to the %s transport', async (transportType, useJsonRpc) => {
+    const bodies = mockToolCalls(2);
+    let resolveHookRequest: () => void;
+    const hookRequestCompleted = new Promise<void>(resolve => {
+      resolveHookRequest = resolve;
     });
-
-    context.transportType = 'jsonrpc';
-    resolveInit(context, false);
-    const listTools = createRequestHandler(HANDLER_CONFIGS.listTools, context);
-    const callTool = createRequestHandler(HANDLER_CONFIGS.callTool, context);
-    await listTools({ id: 1, params: {} });
-    await callTool({ id: 2, params: { name: 'my-tool' } });
-    await flush();
-
-    expect(calls).toEqual([]);
-  });
-
-  it('runs hooks when structured output matches the advertised schema', async () => {
-    nock('https://test-wp.example.com')
-      .post('/?rest_route=/wp/v2/wpmcp')
-      .reply(200, {
-        tools: [
-          {
-            name: 'my-tool',
-            inputSchema: { type: 'object' },
-            outputSchema: {
-              type: 'object',
-              properties: { count: { type: 'number' } },
-              required: ['count'],
-            },
-          },
-        ],
-      })
-      .post('/?rest_route=/wp/v2/wpmcp')
-      .reply(200, {
-        content: [{ type: 'text', text: 'ok' }],
-        structuredContent: { count: 1 },
-      });
-
-    const calls: any[] = [];
-    addHook(() => {
-      calls.push('called');
-    });
-
-    context.transportType = 'jsonrpc';
-    resolveInit(context, false);
-    const listTools = createRequestHandler(HANDLER_CONFIGS.listTools, context);
-    const callTool = createRequestHandler(HANDLER_CONFIGS.callTool, context);
-    await listTools({ id: 1, params: {} });
-    await callTool({ id: 2, params: { name: 'my-tool' } });
-    await flush();
-
-    expect(calls).toEqual(['called']);
-  });
-
-  it('rejects async output schemas before caching their validators', async () => {
-    nock('https://test-wp.example.com')
-      .post('/?rest_route=/wp/v2/wpmcp')
-      .reply(200, {
-        tools: [
-          {
-            name: 'async-tool',
-            inputSchema: { type: 'object' },
-            outputSchema: {
-              $async: true,
-              type: 'object',
-              properties: { count: { type: 'number' } },
-            },
-          },
-        ],
-      });
-
-    context.transportType = 'jsonrpc';
-    resolveInit(context, false);
-    const listTools = createRequestHandler(HANDLER_CONFIGS.listTools, context);
-
-    await expect(listTools({ id: 1, params: {} })).rejects.toThrow(
-      'Async output schemas are not supported for tool async-tool'
-    );
-    expect(context._toolOutputValidators.size).toBe(0);
-  });
-
-  it('keeps the previous validator cache when a tools/list refresh fails', async () => {
-    nock('https://test-wp.example.com')
-      .post('/?rest_route=/wp/v2/wpmcp')
-      .reply(200, {
-        tools: [
-          {
-            name: 'my-tool',
-            inputSchema: { type: 'object' },
-            outputSchema: {
-              type: 'object',
-              properties: { count: { type: 'number' } },
-              required: ['count'],
-            },
-          },
-        ],
-      })
-      .post('/?rest_route=/wp/v2/wpmcp')
-      .reply(200, {
-        tools: [
-          {
-            name: 'my-tool',
-            inputSchema: { type: 'object' },
-            outputSchema: {
-              type: 'object',
-              properties: { count: { type: 'string' } },
-              required: ['count'],
-            },
-          },
-          {
-            name: 'invalid-tool',
-            inputSchema: { type: 'object' },
-            outputSchema: {
-              type: 'object',
-              properties: { value: { type: 'not-a-json-schema-type' } },
-            },
-          },
-        ],
-      })
-      .post('/?rest_route=/wp/v2/wpmcp')
-      .reply(200, {
-        content: [{ type: 'text', text: 'ok' }],
-        structuredContent: { count: 'valid-only-for-the-failed-refresh' },
-      });
-
-    const calls: any[] = [];
-    addHook(() => {
-      calls.push('called');
-    });
-
-    context.transportType = 'jsonrpc';
-    resolveInit(context, false);
-    const listTools = createRequestHandler(HANDLER_CONFIGS.listTools, context);
-    const callTool = createRequestHandler(HANDLER_CONFIGS.callTool, context);
-
-    await listTools({ id: 1, params: {} });
-    const previousValidators = context._toolOutputValidators;
-    await expect(listTools({ id: 2, params: {} })).rejects.toThrow();
-    expect(context._toolOutputValidators).toBe(previousValidators);
-
-    await callTool({ id: 3, params: { name: 'my-tool' } });
-    await flush();
-
-    expect(calls).toEqual([]);
-  });
-
-  it('does not reuse a schema compiled during a failed tools/list refresh', async () => {
-    const schemaId = 'https://example.com/schemas/my-tool-output';
-    nock('https://test-wp.example.com')
-      .post('/?rest_route=/wp/v2/wpmcp')
-      .reply(200, {
-        tools: [
-          {
-            name: 'my-tool',
-            inputSchema: { type: 'object' },
-            outputSchema: {
-              $id: schemaId,
-              type: 'object',
-              properties: { count: { type: 'string' } },
-              required: ['count'],
-            },
-          },
-          {
-            name: 'invalid-tool',
-            inputSchema: { type: 'object' },
-            outputSchema: {
-              type: 'object',
-              properties: { value: { type: 'not-a-json-schema-type' } },
-            },
-          },
-        ],
-      })
-      .post('/?rest_route=/wp/v2/wpmcp')
-      .reply(200, {
-        tools: [
-          {
-            name: 'my-tool',
-            inputSchema: { type: 'object' },
-            outputSchema: {
-              $id: schemaId,
-              type: 'object',
-              properties: { count: { type: 'number' } },
-              required: ['count'],
-            },
-          },
-        ],
-      })
-      .post('/?rest_route=/wp/v2/wpmcp')
-      .reply(200, {
-        content: [{ type: 'text', text: 'ok' }],
-        structuredContent: { count: 1 },
-      });
-
-    const calls: any[] = [];
-    addHook(() => {
-      calls.push('called');
-    });
-
-    context.transportType = 'jsonrpc';
-    resolveInit(context, false);
-    const listTools = createRequestHandler(HANDLER_CONFIGS.listTools, context);
-    const callTool = createRequestHandler(HANDLER_CONFIGS.callTool, context);
-
-    await expect(listTools({ id: 1, params: {} })).rejects.toThrow();
-    await listTools({ id: 2, params: {} });
-    await callTool({ id: 3, params: { name: 'my-tool' } });
-    await flush();
-
-    expect(calls).toEqual(['called']);
-  });
-
-  it('defers hook work until after the tool-call handler resolves', async () => {
-    mockToolCall();
-    const calls: string[] = [];
-    addHook(() => {
-      calls.push('called');
-    });
-
-    const handler = readyHandler('jsonrpc');
-    const response = await handler({ id: 1, params: { name: 'my-tool' } });
-
-    expect(response).toEqual({ content: [{ type: 'text', text: 'ok' }] });
-    expect(calls).toEqual([]);
-
-    await flush();
-    expect(calls).toEqual(['called']);
-  });
-
-  it('a synchronously throwing hook does not affect the client response', async () => {
-    mockToolCall();
-    addHook(() => {
-      throw new Error('sync hook failure');
-    });
-    const calls: any[] = [];
-    addHook((hookContext: any) => {
-      calls.push(hookContext.name);
-    });
-
-    const handler = readyHandler('jsonrpc');
-    const response = await handler({ id: 1, params: { name: 'my-tool' } });
-    await flush();
-
-    expect(response).toEqual({ content: [{ type: 'text', text: 'ok' }] });
-    // Other hooks still ran despite the throwing one
-    expect(calls).toEqual(['my-tool']);
-  });
-
-  it('an async rejecting hook is consumed, not an unhandled rejection', async () => {
-    mockToolCall();
-    addHook(async () => {
-      throw new Error('async hook failure');
-    });
-
-    const unhandled: unknown[] = [];
-    const onRejection = (reason: unknown) => {
-      unhandled.push(reason);
-    };
-    process.on('unhandledRejection', onRejection);
-
-    try {
-      const handler = readyHandler('jsonrpc');
-      const response = await handler({ id: 1, params: { name: 'my-tool' } });
-      await flush();
-
-      expect(response).toEqual({ content: [{ type: 'text', text: 'ok' }] });
-      expect(unhandled).toEqual([]);
-    } finally {
-      process.off('unhandledRejection', onRejection);
-    }
-  });
-
-  it('logs a failing hook instead of silently swallowing it', async () => {
-    mockToolCall();
-    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
-    try {
-      addHook(() => {
-        throw new Error('sync hook failure');
-      });
-      addHook(async () => {
-        throw new Error('async hook failure');
-      });
-
-      const handler = readyHandler('jsonrpc');
-      await handler({ id: 1, params: { name: 'my-tool' } });
-      await flush();
-
-      const messages = errorSpy.mock.calls.map((call: any[]) => call[0]);
-      expect(messages).toEqual(
-        expect.arrayContaining([
-          expect.stringContaining('sync hook failure'),
-          expect.stringContaining('async hook failure'),
-        ])
-      );
-    } finally {
-      errorSpy.mockRestore();
-    }
-  });
-
-  it('a logging failure cannot reopen synchronous or asynchronous hook failures', async () => {
-    mockToolCall();
-    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {
-      throw new Error('logger failure');
-    });
-    const unhandled: unknown[] = [];
-    const onRejection = (reason: unknown) => {
-      unhandled.push(reason);
-    };
-    process.on('unhandledRejection', onRejection);
-
-    try {
-      addHook(() => {
-        throw new Error('sync hook failure');
-      });
-      addHook(async () => {
-        throw new Error('async hook failure');
-      });
-
-      const handler = readyHandler('jsonrpc');
-      const response = await handler({ id: 1, params: { name: 'my-tool' } });
-      await flush();
-
-      expect(response).toEqual({ content: [{ type: 'text', text: 'ok' }] });
-      expect(errorSpy).toHaveBeenCalledTimes(2);
-      expect(unhandled).toEqual([]);
-    } finally {
-      process.off('unhandledRejection', onRejection);
-      errorSpy.mockRestore();
-    }
-  });
-
-  it('an unregistered hook no longer fires', async () => {
-    mockToolCall(2);
-    const calls: any[] = [];
-    const unregister = addHook(() => {
-      calls.push('called');
-    });
-
-    const handler = readyHandler('jsonrpc');
-    await handler({ id: 1, params: { name: 'my-tool' } });
-    await flush();
-    expect(calls).toHaveLength(1);
-
-    unregister();
-    await handler({ id: 2, params: { name: 'my-tool' } });
-    await flush();
-    expect(calls).toHaveLength(1);
-  });
-
-  it('a hook that unregisters and re-registers itself runs once per pass', async () => {
-    // Regression: iterating the live Set would re-visit a hook the pass
-    // re-appended, looping forever and never returning the tool call.
-    mockToolCall(2);
-    let calls = 0;
-    let unregister: () => void;
-    const hook = () => {
-      calls++;
-      unregister();
-      unregister = addHook(hook);
-    };
-    unregister = addHook(hook);
-
-    const handler = readyHandler('jsonrpc');
-    await handler({ id: 1, params: { name: 'my-tool' } });
-    await flush();
-    expect(calls).toBe(1);
-
-    // The re-registered hook still fires on the next pass
-    await handler({ id: 2, params: { name: 'my-tool' } });
-    await flush();
-    expect(calls).toBe(2);
-  });
-
-  it('hook wpRequest sends simple format on a simple-transport session', async () => {
-    const bodies = mockToolCall(2);
-    let hookDispatched: (value?: unknown) => void;
-    const dispatched = new Promise(resolve => {
-      hookDispatched = resolve;
-    });
-    addHook(async (hookContext: any) => {
-      await hookContext.wpRequest({
+    addHook(async ({ wpRequest }: any) => {
+      await wpRequest({
         method: 'tools/call',
         name: 'telemetry-tool',
         arguments: { event: 'test' },
       });
-      hookDispatched();
+      resolveHookRequest();
     });
 
-    const handler = readyHandler('simple');
-    await handler({ id: 1, params: { name: 'my-tool' } });
-    await dispatched;
+    await readyHandler(transportType)({ id: 1, params: { name: 'my-tool' } });
+    await hookRequestCompleted;
 
     expect(bodies).toHaveLength(2);
-    // The hook's request must NOT carry a JSON-RPC envelope on a simple session
-    expect(bodies[1]).not.toHaveProperty('jsonrpc');
-    expect(bodies[1]).toMatchObject({ method: 'tools/call', name: 'telemetry-tool' });
-  });
-
-  it('hook wpRequest sends a JSON-RPC envelope on a jsonrpc session', async () => {
-    const bodies = mockToolCall(2);
-    let hookDispatched: (value?: unknown) => void;
-    const dispatched = new Promise(resolve => {
-      hookDispatched = resolve;
-    });
-    addHook(async (hookContext: any) => {
-      await hookContext.wpRequest({
+    if (useJsonRpc) {
+      expect(bodies[1]).toMatchObject({
+        jsonrpc: '2.0',
         method: 'tools/call',
-        name: 'telemetry-tool',
-        arguments: { event: 'test' },
+        params: { name: 'telemetry-tool' },
       });
-      hookDispatched();
-    });
-
-    const handler = readyHandler('jsonrpc');
-    await handler({ id: 1, params: { name: 'my-tool' } });
-    await dispatched;
-
-    expect(bodies).toHaveLength(2);
-    expect(bodies[1]).toHaveProperty('jsonrpc', '2.0');
-    expect(bodies[1]).toHaveProperty('method', 'tools/call');
-    expect(bodies[1].params).toMatchObject({ name: 'telemetry-tool' });
+    } else {
+      expect(bodies[1]).toMatchObject({ method: 'tools/call', name: 'telemetry-tool' });
+      expect(bodies[1]).not.toHaveProperty('jsonrpc');
+    }
   });
 });


### PR DESCRIPTION
Expose a callback fired after each successful tools/call, receiving the tool name and the proxy's own in-session wpRequest. This lets a package wrapping this proxy run side effects — usage telemetry, auditing — over the existing authenticated session. The handler factory runs the hooks after a successful callTool, with each hook's errors isolated, so a hook can never break the tool call.