### PR TITLE
chore(tooling): make npm run check meaningful and green

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "tsup",
     "build:watch": "tsup --watch",
-    "check": "prettier --check . && tsc",
+    "check": "prettier --check src && tsc",
     "start": "NODE_ENV=development tsup --watch",
     "dev": "NODE_ENV=development node dist/proxy.js",
     "test": "jest",

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -9,7 +9,14 @@
 export { logger, log, LogLevel } from './lib/utils.js';
 
 // Export configuration utilities
-export { CONFIG, getConfig, validateConfig, getDefaultOAuthScopes, parseCustomHeaders, getCustomHeaders } from './lib/config.js';
+export {
+  CONFIG,
+  getConfig,
+  validateConfig,
+  getDefaultOAuthScopes,
+  parseCustomHeaders,
+  getCustomHeaders,
+} from './lib/config.js';
 
 // Export WordPress API utilities
 export { wpRequest } from './lib/wordpress-api.js';
@@ -34,10 +41,21 @@ export {
 export { MCP_WORDPRESS_REMOTE_VERSION } from './lib/utils.js';
 
 // Export fetch utilities (including proxy support)
-export { setupFetchPolyfill, proxyFetch, getProxyInfo, isFetchAvailable, getFetchInfo } from './lib/fetch-utils.js';
+export {
+  setupFetchPolyfill,
+  proxyFetch,
+  getProxyInfo,
+  isFetchAvailable,
+  getFetchInfo,
+} from './lib/fetch-utils.js';
 
 // Export proxy utilities
-export { initializeProxy, isProxyConfigured, getProxyType, getAgentForUrl } from './lib/proxy-utils.js';
+export {
+  initializeProxy,
+  isProxyConfigured,
+  getProxyType,
+  getAgentForUrl,
+} from './lib/proxy-utils.js';
 
 // Export tool-call hooks (embedding packages can piggyback on the live session)
 export { registerToolCallHook } from './lib/tool-call-hooks.js';

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -196,7 +196,7 @@ export function getDefaultOAuthScopes(): string[] {
 /**
  * Parse custom headers from environment variable
  * Supports both JSON format and comma-separated format
- * 
+ *
  * JSON format: {"X-MCP-API-Key": "value", "X-Custom-Header": "value"}
  * Comma format: X-MCP-API-Key:value,X-Custom-Header:value
  */
@@ -254,7 +254,7 @@ export function validateConfig(): { isValid: boolean; errors: string[] } {
   const currentJwtToken = process.env.JWT_TOKEN || CONFIG.JWT_TOKEN;
   const currentUsername = process.env.WP_API_USERNAME || CONFIG.WP_API_USERNAME;
   const currentPassword = process.env.WP_API_PASSWORD || CONFIG.WP_API_PASSWORD;
-  const currentOAuthEnabled = (process.env.OAUTH_ENABLED === 'true') || CONFIG.OAUTH_ENABLED;
+  const currentOAuthEnabled = process.env.OAUTH_ENABLED === 'true' || CONFIG.OAUTH_ENABLED;
 
   // Check if we have at least one authentication method
   const hasJWT = !!currentJwtToken;

--- a/src/lib/error-utils.ts
+++ b/src/lib/error-utils.ts
@@ -1,6 +1,6 @@
 /**
  * Error handling utilities for MCP WordPress Remote
- * 
+ *
  * Provides functions for converting API errors to MCP-compliant error formats
  */
 
@@ -159,13 +159,13 @@ export function mapHttpStatusToMcpCode(statusCode: number): number {
 
   // MCP-specific error codes (in -32000 to -32099 range, using only well-established codes)
   const MCP_ERROR_CODES = {
-    SERVER_ERROR: -32000,       // Generic server error
-    TIMEOUT_ERROR: -32001,      // Request timeout
+    SERVER_ERROR: -32000, // Generic server error
+    TIMEOUT_ERROR: -32001, // Request timeout
     RESOURCE_NOT_FOUND: -32002, // Resource not found
-    TOOL_NOT_FOUND: -32003,     // Tool not found  
-    PROMPT_NOT_FOUND: -32004,   // Prompt not found
-    PERMISSION_DENIED: -32008,  // Access denied/forbidden
-    UNAUTHORIZED: -32010,       // Authentication required
+    TOOL_NOT_FOUND: -32003, // Tool not found
+    PROMPT_NOT_FOUND: -32004, // Prompt not found
+    PERMISSION_DENIED: -32008, // Access denied/forbidden
+    UNAUTHORIZED: -32010, // Authentication required
   };
 
   switch (statusCode) {
@@ -258,7 +258,11 @@ function mcpErrorParts(error: APIError): { code: number; message: string; data?:
   if (wpError) {
     return { code: wpError.code, message: wpError.message ?? error.message, data: wpError.data };
   }
-  return { code: deriveMcpErrorCode(error), message: error.message, data: buildApiErrorData(error) };
+  return {
+    code: deriveMcpErrorCode(error),
+    message: error.message,
+    data: buildApiErrorData(error),
+  };
 }
 
 /**

--- a/src/lib/mcp-oauth-provider.ts
+++ b/src/lib/mcp-oauth-provider.ts
@@ -190,7 +190,7 @@ export class MCPOAuthProvider {
             // Fetch protected resource metadata from the indicated URL
             const metadataResponse = await proxyFetch(authInfo.resource_metadata_url, {
               headers: {
-                'Accept': 'application/json',
+                Accept: 'application/json',
                 ...customHeaders,
               },
             });
@@ -354,9 +354,8 @@ export class MCPOAuthProvider {
       await writeTextFile(this.serverUrlHash, 'oauth_state.txt', this.currentState);
 
       // Step 4: Set up callback server with smart port selection
-      const callbackPort = this.config.callbackPort === 0
-        ? await getOAuthCallbackPort()
-        : this.config.callbackPort;
+      const callbackPort =
+        this.config.callbackPort === 0 ? await getOAuthCallbackPort() : this.config.callbackPort;
 
       const callbackServer = setupWPOAuthCallbackServer(
         {

--- a/src/lib/mcp-oauth-utils.ts
+++ b/src/lib/mcp-oauth-utils.ts
@@ -78,7 +78,7 @@ export async function discoverAuthorizationServerMetadata(
     const customHeaders = getCustomHeaders();
     const response = await proxyFetch(metadataUrl.toString(), {
       headers: {
-        'Accept': 'application/json',
+        Accept: 'application/json',
         ...customHeaders,
       },
     });
@@ -129,7 +129,7 @@ export async function discoverProtectedResourceMetadata(
     const customHeaders = getCustomHeaders();
     const response = await proxyFetch(metadataUrl.toString(), {
       headers: {
-        'Accept': 'application/json',
+        Accept: 'application/json',
         ...customHeaders,
       },
     });

--- a/src/lib/mcp-types.ts
+++ b/src/lib/mcp-types.ts
@@ -1,6 +1,6 @@
 /**
  * MCP Request Types for WordPress Remote Proxy
- * 
+ *
  * Type definitions for all MCP JSON-RPC request schemas
  */
 

--- a/src/lib/node-utils.ts
+++ b/src/lib/node-utils.ts
@@ -1,6 +1,6 @@
 /**
  * Node.js environment utilities for MCP WordPress Remote
- * 
+ *
  * Provides functions for Node.js version checking and environment validation
  */
 
@@ -8,7 +8,7 @@ import { logger } from './utils.js';
 
 /**
  * Check if the current Node.js version meets the minimum requirement
- * 
+ *
  * @param requiredVersion The minimum required Node.js major version
  * @returns true if version is sufficient, false otherwise
  */
@@ -19,12 +19,12 @@ export function checkNodeVersion(requiredVersion: number = 18): boolean {
 
 /**
  * Validate Node.js version and exit if insufficient
- * 
+ *
  * @param requiredVersion The minimum required Node.js major version
  */
 export function validateNodeVersion(requiredVersion: number = 18): void {
   const currentNodeVersion = parseInt(process.version.slice(1).split('.')[0]);
-  
+
   if (currentNodeVersion < requiredVersion) {
     logger.error(
       `This application requires Node.js version ${requiredVersion} or higher.`,
@@ -37,14 +37,14 @@ export function validateNodeVersion(requiredVersion: number = 18): void {
 
 /**
  * Get the current Node.js version information
- * 
+ *
  * @returns Object containing version details
  */
 export function getNodeVersionInfo() {
   const fullVersion = process.version;
   const majorVersion = parseInt(fullVersion.slice(1).split('.')[0]);
   const [, minor, patch] = fullVersion.slice(1).split('.').map(Number);
-  
+
   return {
     full: fullVersion,
     major: majorVersion,

--- a/src/lib/oauth-types.ts
+++ b/src/lib/oauth-types.ts
@@ -137,7 +137,13 @@ export class APIError extends Error {
   /** Underlying network/TLS error code (e.g. "UNABLE_TO_VERIFY_LEAF_SIGNATURE"), when the failure was below the HTTP layer. */
   public readonly code?: string;
 
-  constructor(message: string, statusCode: number, endpoint: string, response?: any, code?: string) {
+  constructor(
+    message: string,
+    statusCode: number,
+    endpoint: string,
+    response?: any,
+    code?: string
+  ) {
     super(message);
     this.name = 'APIError';
     this.statusCode = statusCode;

--- a/src/lib/persistent-auth-config.ts
+++ b/src/lib/persistent-auth-config.ts
@@ -295,11 +295,11 @@ export function isTokenValid(tokens: WPTokens): TokenValidationResult {
 
   // Optimized expiration check - avoid Math.floor until needed
   const now = Date.now();
-  const expiryTime = tokens.obtained_at + (tokens.expires_in * 1000);
-  
+  const expiryTime = tokens.obtained_at + tokens.expires_in * 1000;
+
   // Quick check with 60-second buffer for token refresh
-  const isExpiringSoon = now >= (expiryTime - 60000);
-  
+  const isExpiringSoon = now >= expiryTime - 60000;
+
   if (isExpiringSoon) {
     const expiresIn = Math.max(0, Math.floor((expiryTime - now) / 1000));
     return {
@@ -311,9 +311,9 @@ export function isTokenValid(tokens: WPTokens): TokenValidationResult {
 
   // Token is valid with plenty of time left
   const expiresIn = Math.floor((expiryTime - now) / 1000);
-  return { 
+  return {
     isValid: true,
-    expiresIn: Math.max(0, expiresIn)
+    expiresIn: Math.max(0, expiresIn),
   };
 }
 

--- a/src/lib/persistent-oauth-client-provider.ts
+++ b/src/lib/persistent-oauth-client-provider.ts
@@ -16,8 +16,6 @@ import { setupWPOAuthCallbackServer } from './oauth-callback-server.js';
 import { logger } from './utils.js';
 import { CONFIG, getDefaultOAuthScopes, getOAuthCallbackPort } from './config.js';
 
-
-
 /**
  * Persistent WordPress OAuth Client Provider
  * Stores tokens permanently in ~/.mcp-auth/wordpress-remote-{version}/
@@ -200,10 +198,9 @@ export class PersistentWPOAuthClientProvider {
    */
   private async performAuthorization(): Promise<WPTokens> {
     // Use smart port selection or fixed port as configured
-    const callbackPort = this.options.callbackPort === 0 
-      ? await getOAuthCallbackPort() 
-      : this.options.callbackPort;
-      
+    const callbackPort =
+      this.options.callbackPort === 0 ? await getOAuthCallbackPort() : this.options.callbackPort;
+
     const callbackServerOptions = {
       port: callbackPort,
       host: this.options.host,
@@ -297,7 +294,10 @@ export class PersistentWPOAuthClientProvider {
     }
 
     // Check if authorizeEndpoint is a full URL or relative path
-    if (this.options.authorizeEndpoint.startsWith('http://') || this.options.authorizeEndpoint.startsWith('https://')) {
+    if (
+      this.options.authorizeEndpoint.startsWith('http://') ||
+      this.options.authorizeEndpoint.startsWith('https://')
+    ) {
       // Full URL - use as is
       return `${this.options.authorizeEndpoint}?${params.toString()}`;
     } else {

--- a/src/lib/proxy-utils.ts
+++ b/src/lib/proxy-utils.ts
@@ -99,8 +99,8 @@ export function shouldBypassProxy(targetUrl: string): boolean {
 
   const rules = noProxy
     .split(',')
-    .map((r) => r.trim().toLowerCase())
-    .filter((r) => r.length > 0);
+    .map(r => r.trim().toLowerCase())
+    .filter(r => r.length > 0);
 
   for (const rule of rules) {
     if (rule === '*') return true;
@@ -164,7 +164,7 @@ export async function initializeProxy(
     return initializationPromise;
   }
 
-  initializationPromise = doInitializeProxy(detectMacOs).catch((error) => {
+  initializationPromise = doInitializeProxy(detectMacOs).catch(error => {
     initializationPromise = null;
     throw error;
   });
@@ -271,7 +271,10 @@ export async function getAgentForUrl(url: string): Promise<ProxyAgent | undefine
         const socksMatch = directive.match(/SOCKS5?\s+(\S+):(\d+)/i);
         if (socksMatch) {
           const proxyUrl = `socks5h://${socksMatch[1]}:${socksMatch[2]}`;
-          logger.debug(`PAC returned SOCKS proxy for ${url}: ${sanitizeProxyUrl(proxyUrl)}`, 'PROXY');
+          logger.debug(
+            `PAC returned SOCKS proxy for ${url}: ${sanitizeProxyUrl(proxyUrl)}`,
+            'PROXY'
+          );
           return new SocksProxyAgent(proxyUrl);
         }
 
@@ -279,7 +282,10 @@ export async function getAgentForUrl(url: string): Promise<ProxyAgent | undefine
         const proxyMatch = directive.match(/PROXY\s+(\S+):(\d+)/i);
         if (proxyMatch) {
           const proxyUrl = `http://${proxyMatch[1]}:${proxyMatch[2]}`;
-          logger.debug(`PAC returned HTTP proxy for ${url}: ${sanitizeProxyUrl(proxyUrl)}`, 'PROXY');
+          logger.debug(
+            `PAC returned HTTP proxy for ${url}: ${sanitizeProxyUrl(proxyUrl)}`,
+            'PROXY'
+          );
           return new HttpsProxyAgent(proxyUrl);
         }
       }
@@ -296,9 +302,7 @@ export async function getAgentForUrl(url: string): Promise<ProxyAgent | undefine
     const { url: proxyUrl, type } = proxyConfig.envProxy;
     try {
       logger.debug(`Using env proxy ${sanitizeProxyUrl(proxyUrl)} for ${url}`, 'PROXY');
-      return type === 'socks'
-        ? new SocksProxyAgent(proxyUrl)
-        : new HttpsProxyAgent(proxyUrl);
+      return type === 'socks' ? new SocksProxyAgent(proxyUrl) : new HttpsProxyAgent(proxyUrl);
     } catch (error) {
       logger.error(`Invalid proxy URL "${proxyUrl}": ${error}`, 'PROXY');
       return undefined;

--- a/src/lib/request-handler-factory.ts
+++ b/src/lib/request-handler-factory.ts
@@ -1,6 +1,6 @@
 /**
  * Request Handler Factory for MCP WordPress Remote
- * 
+ *
  * Creates standardized request handlers to eliminate repetitive code
  */
 
@@ -77,12 +77,12 @@ export function createRequestHandler(config: HandlerConfig, context: SessionCont
  */
 export function createWrappedHandler(config: HandlerConfig, context: SessionContext) {
   const handler = createRequestHandler(config, context);
-  
+
   return async (request: any) => {
     // Enhanced client message logging
     logger.info(`📩 Client Message: ${config.name}`, 'CLIENT');
     logger.info(`Request ID: ${request.id || 'none'} | Method: ${config.method}`, 'CLIENT');
-    
+
     // Log request parameters in a structured way
     if (request.params && Object.keys(request.params).length > 0) {
       logger.info(`Request parameters:`, 'CLIENT', {
@@ -93,45 +93,50 @@ export function createWrappedHandler(config: HandlerConfig, context: SessionCont
     } else {
       logger.info(`No request parameters`, 'CLIENT');
     }
-    
+
     // Log session context
     logger.debug(
       `Session context - ID: ${context.sessionId || 'none'}, Transport: ${context.transportType || 'detecting'}, Counter: ${context.requestIdCounter}`,
       'CLIENT'
     );
-    
+
     // Log full request object at debug level for detailed debugging
     logger.debug(`Complete client request object:`, 'CLIENT', request);
-    
+
     const startTime = Date.now();
-    
+
     try {
       const response = await handler(request);
       const duration = Date.now() - startTime;
-      
+
       logger.info(`✅ Client Response: ${config.name} completed in ${duration}ms`, 'CLIENT');
       logger.debug(`Response sent to client:`, 'CLIENT', {
         hasResponse: !!response,
-        responseKeys: response && typeof response === 'object' ? Object.keys(response) : 'primitive',
+        responseKeys:
+          response && typeof response === 'object' ? Object.keys(response) : 'primitive',
       });
-      
+
       return response;
     } catch (error) {
       const duration = Date.now() - startTime;
-      
+
       logger.error(`❌ Client Error: ${config.name} failed after ${duration}ms`, 'CLIENT', {
         error: error instanceof Error ? error.message : String(error),
         requestId: request.id,
       });
-      
+
       if (isAPIError(error)) {
         // Simple transport returns errors as a tool result.
         if (context.transportType === 'simple') {
-          logger.debug(`Converting APIError to MCP error format for ${config.name} (simple transport)`, 'MCP', {
-            statusCode: error.statusCode,
-            endpoint: error.endpoint,
-            message: error.message,
-          });
+          logger.debug(
+            `Converting APIError to MCP error format for ${config.name} (simple transport)`,
+            'MCP',
+            {
+              statusCode: error.statusCode,
+              endpoint: error.endpoint,
+              message: error.message,
+            }
+          );
           return convertAPIErrorToMcpError(error);
         }
 
@@ -140,12 +145,16 @@ export function createWrappedHandler(config: HandlerConfig, context: SessionCont
         // HTTP-status errors, and surfaces below-HTTP failures with code + hint.
         // Throwing a plain Error here would let the SDK flatten everything to
         // -32603 and drop WordPress's real error code.
-        logger.debug(`Converting APIError to McpError for ${config.name} (jsonrpc transport)`, 'MCP', {
-          statusCode: error.statusCode,
-          code: error.code,
-          endpoint: error.endpoint,
-          message: error.message,
-        });
+        logger.debug(
+          `Converting APIError to McpError for ${config.name} (jsonrpc transport)`,
+          'MCP',
+          {
+            statusCode: error.statusCode,
+            code: error.code,
+            endpoint: error.endpoint,
+            message: error.message,
+          }
+        );
         throw apiErrorToMcpError(error);
       }
 
@@ -162,109 +171,109 @@ export const HANDLER_CONFIGS: Record<string, HandlerConfig> = {
   listTools: {
     name: 'ListTools',
     method: 'tools/list',
-    paramMapper: (request) => ({
+    paramMapper: request => ({
       method: 'tools/list',
       cursor: request.params?.cursor,
     }),
   },
-  
+
   callTool: {
-    name: 'CallTool', 
+    name: 'CallTool',
     method: 'tools/call',
-    paramMapper: (request) => ({
+    paramMapper: request => ({
       method: 'tools/call',
       name: request.params.name,
       arguments: request.params.arguments,
     }),
   },
-  
+
   listResources: {
     name: 'ListResources',
     method: 'resources/list',
-    paramMapper: (request) => ({
+    paramMapper: request => ({
       method: 'resources/list',
       cursor: request.params?.cursor,
     }),
   },
-  
+
   listResourceTemplates: {
     name: 'ListResourceTemplates',
     method: 'resources/templates/list',
-    paramMapper: (request) => ({
+    paramMapper: request => ({
       method: 'resources/templates/list',
       cursor: request.params?.cursor,
     }),
   },
-  
+
   readResource: {
     name: 'ReadResource',
     method: 'resources/read',
-    paramMapper: (request) => ({
+    paramMapper: request => ({
       method: 'resources/read',
       uri: request.params.uri,
     }),
   },
-  
+
   subscribe: {
     name: 'Subscribe',
     method: 'resources/subscribe',
-    paramMapper: (request) => ({
+    paramMapper: request => ({
       method: 'resources/subscribe',
       uri: request.params.uri,
     }),
   },
-  
+
   unsubscribe: {
     name: 'Unsubscribe',
     method: 'resources/unsubscribe',
-    paramMapper: (request) => ({
+    paramMapper: request => ({
       method: 'resources/unsubscribe',
       uri: request.params.uri,
     }),
   },
-  
+
   listPrompts: {
     name: 'ListPrompts',
     method: 'prompts/list',
-    paramMapper: (request) => ({
+    paramMapper: request => ({
       method: 'prompts/list',
       cursor: request.params?.cursor,
     }),
   },
-  
+
   getPrompt: {
     name: 'GetPrompt',
     method: 'prompts/get',
-    paramMapper: (request) => ({
+    paramMapper: request => ({
       method: 'prompts/get',
       name: request.params.name,
       arguments: request.params.arguments,
     }),
   },
-  
+
   setLevel: {
     name: 'SetLevel',
     method: 'logging/setLevel',
-    paramMapper: (request) => ({
+    paramMapper: request => ({
       method: 'logging/setLevel',
       level: request.params.level,
     }),
   },
-  
+
   complete: {
     name: 'Complete',
     method: 'completion/complete',
-    paramMapper: (request) => ({
+    paramMapper: request => ({
       method: 'completion/complete',
       ref: request.params.ref,
       argument: request.params.argument,
     }),
   },
-  
+
   listRoots: {
     name: 'ListRoots',
     method: 'roots/list',
-    paramMapper: (request) => ({
+    paramMapper: request => ({
       method: 'roots/list',
     }),
   },

--- a/src/lib/session-utils.ts
+++ b/src/lib/session-utils.ts
@@ -83,7 +83,9 @@ export function prepareRequest(
  */
 export function createSessionContext(): SessionContext {
   let resolve: () => void;
-  const ready = new Promise<void>(r => { resolve = r; });
+  const ready = new Promise<void>(r => {
+    resolve = r;
+  });
 
   return {
     sessionId: null,
@@ -129,7 +131,10 @@ export type InitResult =
   | { ready: true }
   | { ready: false; reason: 'failed' | 'timeout'; error?: ConnectionErrorInfo };
 
-export async function waitForInit(context: SessionContext, timeoutMs = INIT_TIMEOUT_MS): Promise<InitResult> {
+export async function waitForInit(
+  context: SessionContext,
+  timeoutMs = INIT_TIMEOUT_MS
+): Promise<InitResult> {
   // Fast path: init already settled, no async work needed
   if (context._init.settled) {
     return context._init.failed

--- a/src/lib/transport-detection.ts
+++ b/src/lib/transport-detection.ts
@@ -1,6 +1,6 @@
 /**
  * Transport Detection Utilities for MCP WordPress Remote
- * 
+ *
  * Provides automatic detection of transport type (JSON-RPC vs Simple)
  */
 
@@ -23,71 +23,85 @@ export interface TransportDetectionResult {
  * Detect which transport type the WordPress server supports
  * Tries JSON-RPC first, falls back to simple format
  */
-export async function detectTransportType(context: SessionContext, initParams?: any): Promise<TransportDetectionResult> {
-  logger.info('🔍 Starting transport detection and WordPress API initialization...', 'TRANSPORT_DETECT');
-  
+export async function detectTransportType(
+  context: SessionContext,
+  initParams?: any
+): Promise<TransportDetectionResult> {
+  logger.info(
+    '🔍 Starting transport detection and WordPress API initialization...',
+    'TRANSPORT_DETECT'
+  );
+
   let init: InitializeResult;
   let transportType: TransportType = null;
-  
+
   // Add proxy information to clientInfo
   const enhancedParams = initParams ? { ...initParams } : {};
   if (enhancedParams.clientInfo) {
     // Verify clientInfo is a non-null object (not an array)
-    if (typeof enhancedParams.clientInfo === 'object' && enhancedParams.clientInfo !== null && !Array.isArray(enhancedParams.clientInfo)) {
+    if (
+      typeof enhancedParams.clientInfo === 'object' &&
+      enhancedParams.clientInfo !== null &&
+      !Array.isArray(enhancedParams.clientInfo)
+    ) {
       // Capture original client name before any mutation
       const originalClient = enhancedParams.clientInfo?.name || 'unknown';
-      
+
       // Create a fresh newClientInfo object to avoid mutating the original
       const newClientInfo = { ...enhancedParams.clientInfo };
-      
+
       // Add/merge the proxied field without clobbering an existing proxied object
       if (newClientInfo.proxied && typeof newClientInfo.proxied === 'object') {
         // If proxied already exists, merge with it
         newClientInfo.proxied = {
           ...newClientInfo.proxied,
           name: '@automattic/mcp-wordpress-remote',
-          version: MCP_WORDPRESS_REMOTE_VERSION
+          version: MCP_WORDPRESS_REMOTE_VERSION,
         };
       } else {
         // If no proxied field exists, create it
         newClientInfo.proxied = {
           name: '@automattic/mcp-wordpress-remote',
-          version: MCP_WORDPRESS_REMOTE_VERSION
+          version: MCP_WORDPRESS_REMOTE_VERSION,
         };
       }
-      
+
       // Assign the new clientInfo to enhancedParams (original initParams remains unchanged)
       enhancedParams.clientInfo = newClientInfo;
-      
+
       logger.info('📋 Added proxy information to clientInfo', 'TRANSPORT_DETECT', {
         originalClient,
         proxyName: '@automattic/mcp-wordpress-remote',
-        proxyVersion: MCP_WORDPRESS_REMOTE_VERSION
+        proxyVersion: MCP_WORDPRESS_REMOTE_VERSION,
       });
     } else {
-      logger.warn('clientInfo is present but not a valid object, skipping enhancement', 'TRANSPORT_DETECT', {
-        clientInfoType: typeof enhancedParams.clientInfo,
-        isArray: Array.isArray(enhancedParams.clientInfo),
-        isNull: enhancedParams.clientInfo === null
-      });
+      logger.warn(
+        'clientInfo is present but not a valid object, skipping enhancement',
+        'TRANSPORT_DETECT',
+        {
+          clientInfoType: typeof enhancedParams.clientInfo,
+          isArray: Array.isArray(enhancedParams.clientInfo),
+          isNull: enhancedParams.clientInfo === null,
+        }
+      );
     }
   } else {
     logger.debug('No clientInfo provided in initialize parameters', 'TRANSPORT_DETECT');
   }
-  
+
   try {
     // First, try JSON-RPC format
     logger.info('📡 Attempting JSON-RPC transport...', 'TRANSPORT_DETECT');
-    
+
     // Prepare the initialize request with client parameters
     // Include client params in wpRequestParams so they end up in the JSON-RPC params field
     const wpRequestParams = {
       method: 'initialize',
-      ...enhancedParams
+      ...enhancedParams,
     };
-    
+
     const initMessage = addSessionInfo(wpRequestParams, {}, context);
-    
+
     logger.info('Sending initialization message via JSON-RPC:', 'TRANSPORT_DETECT', {
       method: initMessage.method,
       id: initMessage.id,
@@ -95,11 +109,11 @@ export async function detectTransportType(context: SessionContext, initParams?: 
       hasParams: !!initMessage.params && Object.keys(initMessage.params).length > 1, // More than just _proxy_request_id
     });
     logger.debug('Complete JSON-RPC init message:', 'TRANSPORT_DETECT', initMessage);
-    
+
     const initResponse = await wpRequest(initMessage, true); // Use JSON-RPC
     init = initResponse as InitializeResult;
     transportType = 'jsonrpc';
-    
+
     logger.info('✅ JSON-RPC transport detected and working', 'TRANSPORT_DETECT');
     logger.debug('JSON-RPC initialization response:', 'TRANSPORT_DETECT', init);
   } catch (error) {
@@ -122,52 +136,61 @@ export async function detectTransportType(context: SessionContext, initParams?: 
     // If JSON-RPC fails for another reason, try simple format
     logger.warn('⚠️  JSON-RPC transport failed, trying simple transport...', 'TRANSPORT_DETECT');
     logger.debug('JSON-RPC error details:', 'TRANSPORT_DETECT', error);
-    
+
     try {
       // For simple transport, use the same enhanced params structure
       const simpleRequestParams = {
         method: 'initialize',
-        ...enhancedParams
+        ...enhancedParams,
       };
-      
+
       logger.info('Sending initialization message via Simple transport:', 'TRANSPORT_DETECT', {
         method: simpleRequestParams.method,
         hasParams: Object.keys(simpleRequestParams).length > 1,
       });
       logger.debug('Complete Simple init message:', 'TRANSPORT_DETECT', simpleRequestParams);
-      
+
       const initResponse = await wpRequest(simpleRequestParams, false); // Use simple format
       init = initResponse as InitializeResult;
       transportType = 'simple';
-      
+
       logger.info('✅ Simple transport detected and working', 'TRANSPORT_DETECT');
       logger.debug('Simple initialization response:', 'TRANSPORT_DETECT', init);
     } catch (simpleError) {
-      logger.error('❌ Both JSON-RPC and simple transports failed', 'TRANSPORT_DETECT', simpleError);
+      logger.error(
+        '❌ Both JSON-RPC and simple transports failed',
+        'TRANSPORT_DETECT',
+        simpleError
+      );
       // Preserve the underlying failure as `cause` so the init handler can
       // surface the real reason (TLS, DNS, refused) instead of a generic message.
       // Assigned post-construction because the tsconfig lib predates the
       // two-argument Error constructor.
-      const connectionError = new Error('Unable to establish connection with either transport type');
+      const connectionError = new Error(
+        'Unable to establish connection with either transport type'
+      );
       (connectionError as { cause?: unknown }).cause = simpleError;
       throw connectionError;
     }
   }
-  
+
   // Update context with detected transport type
   context.transportType = transportType;
-  
+
   // Get the session ID that WordPress provided
   const sessionId = getSessionId();
   context.sessionId = sessionId;
-  
+
   if (sessionId) {
     logger.info(`Using session ID from WordPress: ${sessionId}`, 'PROXY');
   } else {
     logger.warn('No session ID received from WordPress - continuing without session', 'PROXY');
   }
-  
-  logger.info(`WordPress connection initialized successfully using ${transportType} transport`, 'PROXY');
+
+  logger.info(
+    `WordPress connection initialized successfully using ${transportType} transport`,
+    'PROXY'
+  );
 
   return {
     transportType,

--- a/src/lib/wordpress-api.ts
+++ b/src/lib/wordpress-api.ts
@@ -171,10 +171,7 @@ async function getOAuthTokens(): Promise<WPTokens | null> {
       }
     } else {
       // Use legacy OAuth provider
-      logger.warn(
-        'Using legacy OAuth provider. Consider enabling PKCE for MCP compliance',
-        'AUTH'
-      );
+      logger.warn('Using legacy OAuth provider. Consider enabling PKCE for MCP compliance', 'AUTH');
 
       // Initialize coordinator for legacy flow
       if (!authCoordinator) {
@@ -339,14 +336,10 @@ async function executeWordPressRequest(
     // Determine method and tool name based on transport type
     const method = useJsonRpc ? requestData.method : requestData.method;
     const toolName = useJsonRpc
-      ? (requestData.params?.name || requestData.params?.tool)
-      : (requestData.name || requestData.tool || requestData.args?.tool);
+      ? requestData.params?.name || requestData.params?.tool
+      : requestData.name || requestData.tool || requestData.args?.tool;
 
-    if (
-      method === 'tools/call' &&
-      toolName &&
-      toolName.startsWith('wc_reports_')
-    ) {
+    if (method === 'tools/call' && toolName && toolName.startsWith('wc_reports_')) {
       // Use WooCommerce credentials for WooCommerce report tools
       username = CONFIG.WOO_CUSTOMER_KEY!;
       password = CONFIG.WOO_CUSTOMER_SECRET!;
@@ -540,7 +533,10 @@ async function executeWordPressRequest(
 
 async function refreshSession(failedSessionId: string | null): Promise<void> {
   if (failedSessionId && globalSessionId && globalSessionId !== failedSessionId) {
-    logger.info('Detected newer session while handling invalid-session error; skipping refresh', 'SESSION');
+    logger.info(
+      'Detected newer session while handling invalid-session error; skipping refresh',
+      'SESSION'
+    );
     return;
   }
 
@@ -617,11 +613,7 @@ export async function wpRequest(
 
       await refreshSession(sessionIdUsed);
 
-      const retriedResult = await executeWordPressRequest(
-        requestData,
-        useJsonRpc,
-        globalSessionId
-      );
+      const retriedResult = await executeWordPressRequest(requestData, useJsonRpc, globalSessionId);
       return retriedResult.responseData;
     }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -146,7 +146,9 @@ async function WordPressProxy() {
           version: MCP_WORDPRESS_REMOTE_VERSION,
         },
         capabilities: {
-          experimental: { connectionFailed: connectionError.code ? { code: connectionError.code } : {} },
+          experimental: {
+            connectionFailed: connectionError.code ? { code: connectionError.code } : {},
+          },
         },
         instructions: `MCP WordPress Remote Proxy Server (Connection Failed${
           connectionError.code ? `: ${connectionError.code}` : ''


### PR DESCRIPTION
Fixes `npm run check`, which has been failing on 86 files and therefore telling us nothing.

## Why it was red

Two unrelated causes, neither of them `tsc` — that part always passed.

**51 of the 86 were not in the repository.** `.prettierignore` lists only `dist` and `node_modules`, so `prettier --check .` walked untracked local scratch directories that do not exist in a fresh clone. Pure noise.

**The remaining 35 were genuine drift** — trailing whitespace, lines past the configured `printWidth` of 100, and one pair of redundant parentheses. Nothing ever enforced the format: there is no pre-commit hook, and the only workflow, `release.yml`, runs on release and never invokes `check`.

## What this does

Two commits, kept separate on purpose:

- `chore(tooling)` — scope the script to `prettier --check src`. One line. `tsc` is unchanged and still typechecks the whole project via `tsconfig`.
- `style(src)` — `prettier --write src` over the 16 offending source files.

Splitting them means the 215-line formatting commit is isolated, so it can be dropped into `.git-blame-ignore-revs` without taking the tooling change with it.

## Verification

`npm run check` exits 0. Build clean. Unit and integration suites: 225 passing, 15 suites.

The formatting commit is semantically inert — `git diff -w` reduces it to line wrapping alone, and the one paren removal is `(process.env.OAUTH_ENABLED === 'true') || CONFIG.OAUTH_ENABLED` losing parentheses that `===` already made redundant.

## Tradeoff worth naming

Scoping to `src` drops 19 tracked files out of format checking — `tests/` (13 files), `Docs/`, `README.md`, `playwright.config.ts`. They are unformatted today and nothing will watch them. If we would rather keep tests covered, `prettier --check src tests` plus a format pass over those 13 does it.

Separately: nothing currently *runs* `check`. Wiring it into CI on push/PR is the follow-up that makes this stick.