### PR TITLE
fix(tooling): stop npm run check from overwriting the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "tsup",
     "build:watch": "tsup --watch",
-    "check": "prettier --check src && tsc",
+    "check": "prettier --check src && tsc --noEmit",
     "start": "NODE_ENV=development tsup --watch",
     "dev": "NODE_ENV=development node dist/proxy.js",
     "test": "jest",


### PR DESCRIPTION
One-line fix: `tsc` → `tsc --noEmit` in the `check` script.

## The bug

`tsconfig.json` sets `outDir: ./dist` and does not set `noEmit`. The bare `tsc` at the end of `check` therefore **emits**, writing unbundled per-file output straight over the tsup bundle.

Observed directly:

```
after npm run build:   dist/proxy.js = 2.5M,  no dist/lib
after npm run check:   dist/proxy.js = 9.5K,  dist/lib/ present
```

The 9.5 KB file keeps live `import ... from './lib/config.js'` specifiers pointing into a `dist/lib` tree that `package.json` `files` does not publish. `npm pack` at that moment would produce an artifact that cannot start.

## Why it surfaced now and not earlier

It was latent, not new. `prettier --check .` had always failed, so `&&` short-circuited and `tsc` never ran at all. Scoping the format check in #97 made prettier pass, which let `tsc` execute for the first time — and immediately clobber the build.

That is worth stating plainly: #97 did not introduce this, but it did remove the accident that was hiding it. Anyone running `build` then `check` before publishing would have shipped a broken tarball.

## Verification

With the fix, the bundle survives:

```
after npm run build:   dist/proxy.js = 2.5M,  no dist/lib
after npm run check:   dist/proxy.js = 2.5M,  no dist/lib   ← unchanged
```

`npm run check` still exits 0 and still typechecks the whole project — `--noEmit` changes only whether output is written.