### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/mcp-wordpress-remote",
-      "version": "0.3.5",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/mcp-wordpress-remote",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "MCP WordPress Remote proxy server",
   "engines": {
     "node": ">=18.0.0"

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,7 +4,7 @@ import { selectCallbackPort } from './port-utils.js';
 import { logger } from './utils.js';
 
 // Version constant - update this manually when releasing new versions
-export const MCP_WORDPRESS_REMOTE_VERSION = '0.3.5';
+export const MCP_WORDPRESS_REMOTE_VERSION = '0.4.0';
 
 /**
  * Parse a positive integer from an environment variable, falling back to a


### PR DESCRIPTION
Bumps the package to 0.4.0 in all three places that carry a version: `package.json`, `package-lock.json`, and the `MCP_WORDPRESS_REMOTE_VERSION` constant in `src/lib/config.ts`.

The constant moves in the same commit as `package.json` on purpose. They are independent sources of truth, and letting them drift is what previously shipped a config directory literally named `wordpress-remote-undefined` (see #85).

## Minor, not patch

Every prior 0.3.x bump carried only `fix:` commits. This release adds a new public API — `registerToolCallHook`, exported from the `/lib` entrypoint (#92) — alongside the `fast-uri` and `hono` bumps (#95, #94).

## Release gate

Run against the packed tarball installed into a clean directory, per the checklist in CLAUDE.md.

| Step | Result |
| --- | --- |
| `npm run build` | 2.43 MB bundle, DTS emitted |
| `npm run check` | exits 0 |
| Unit + integration | 225 passing, 15 suites |
| `npm pack` → clean-dir install | 0.4.0, entry intact at 2.5 MB |
| Healthy endpoint | `WordPress.com MCP Server v0.2.0`, 25 tools |
| Broken endpoint | fallback init, `connectionFailed: ENOTFOUND`, clean `-32603` |
| Forwarding after fallback | **0 requests** |

The hook feature from #92 was also exercised end-to-end against a live WordPress.com session: the hook fires with the correct tool name, its `wpRequest` reuses the authenticated session without re-authenticating, and hooks that throw synchronously or reject asynchronously are isolated and logged while the tool call still returns clean.

## Two things to know before publishing

**Upgrading invalidates every user's OAuth tokens.** The token store is namespaced `wordpress-remote-<version>`, so a fresh 0.4.0 finds no tokens and starts a full OAuth flow. This surfaced during the gate — the packed build hung on its callback server until the token directory was seeded. Pre-existing behaviour, not introduced here, but 0.4.0 is a reasonable moment to decide whether it is intended.

**`--help` does not exist.** The CLAUDE.md gate lists `npx mcp-wordpress-remote --help` as a step, but there is no argv handling anywhere in `src/`; the binary starts the stdio server and hangs with no output. Also pre-existing — 0.3.5 behaves identically — but the documented step cannot pass as written.