### PR TITLE
Fix dynamic OAuth callback port during token exchange

### DIFF
--- a/src/lib/mcp-oauth-provider.ts
+++ b/src/lib/mcp-oauth-provider.ts
@@ -403,7 +403,7 @@ export class MCPOAuthProvider {
       const authCode = await this.waitForAuthorizationCode();
 
       // Step 8: Exchange authorization code for access token
-      const tokens = await this.exchangeCodeForTokens(authCode);
+      const tokens = await this.exchangeCodeForTokens(authCode, actualRedirectUri);
 
       // Step 9: Store tokens
       await writeTokens(this.serverUrlHash, tokens);
@@ -456,7 +456,10 @@ export class MCPOAuthProvider {
   /**
    * Exchange authorization code for access tokens
    */
-  private async exchangeCodeForTokens(code: string): Promise<WPTokens> {
+  private async exchangeCodeForTokens(
+    code: string,
+    redirectUri = this.config.redirectUri
+  ): Promise<WPTokens> {
     try {
       const codeVerifier = await readTextFile(
         this.serverUrlHash,
@@ -467,7 +470,7 @@ export class MCPOAuthProvider {
       const tokenResponse = await exchangeAuthorizationCode(
         this.config.tokenEndpoint!,
         code,
-        this.config.redirectUri,
+        redirectUri,
         this.config.clientId!,
         codeVerifier,
         CONFIG.OAUTH_RESOURCE_INDICATOR ? this.config.resource : undefined

--- a/tests/unit/mcp-oauth-provider.test.ts
+++ b/tests/unit/mcp-oauth-provider.test.ts
@@ -160,4 +160,26 @@ describe('MCPOAuthProvider client registration', () => {
     expect(scope.isDone()).toBe(false);
     expect(provider.getConfig().clientId).toBe('env-client');
   });
+
+  it('uses the selected callback port when exchanging the authorization code', async () => {
+    const { MCPOAuthProvider, generateServerUrlHash } = await loadModules();
+    const { writeTextFile } = await import('../../src/lib/persistent-auth-config.js');
+    const provider = new MCPOAuthProvider({
+      serverUrl,
+      clientId: 'dynamic-port-client',
+      scopes: ['read'],
+    });
+    (provider as any).config.tokenEndpoint = `${origin}/oauth/token`;
+
+    await writeTextFile(generateServerUrlHash(serverUrl), 'pkce_verifier.txt', 'a'.repeat(64));
+
+    const callback = 'http://127.0.0.1:49152/oauth/callback';
+    const exchange = nock(origin)
+      .post('/oauth/token', body => body.redirect_uri === callback)
+      .reply(200, { access_token: 'access-token', token_type: 'Bearer', expires_in: 3600 });
+
+    await (provider as any).exchangeCodeForTokens('authorization-code', callback);
+
+    expect(exchange.isDone()).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- pass the selected OAuth callback URL to the token exchange
- keep fixed-port behavior unchanged
- add regression coverage for dynamically selected ports

## Why
The provider registers a loopback redirect with port 0, then selects a concrete local port before authorization. The token exchange was still sending the original port 0 URL, so standards-compliant authorization servers rejected the code binding.

## Testing
- npm test -- --runInBand tests/unit/mcp-oauth-provider.test.ts
- npm run check