### PR TITLE
fix: recover expired sessions and stale proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ For WooCommerce-specific tools and reports:
 | `LOG_TO_STDERR`               | Mirror all log levels to stderr (errors always are) | `false`           | -                     |
 | `WP_API_TIMEOUT_MS`           | Request timeout for tool calls (ms)              | `120000`             | -                     |
 | `WP_API_INIT_TIMEOUT_MS`      | Timeout for the initialize handshake (ms)        | `25000`              | -                     |
+| `PROXY_PAC_TIMEOUT_MS`        | Timeout for PAC download and resolver setup (ms) | `5000`               | -                     |
 | **TLS / Certificates**        |                                                  |                      |                       |
 | `NODE_EXTRA_CA_CERTS`         | Path to an extra CA file to trust (mkcert/corporate CA) | -             | -                     |
 | `NODE_USE_SYSTEM_CA`          | Trust the OS certificate store (Node 22.15+)     | -                    | -                     |

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -44,6 +44,8 @@ export { MCP_WORDPRESS_REMOTE_VERSION } from './lib/utils.js';
 export {
   setupFetchPolyfill,
   proxyFetch,
+  ProxyFetchError,
+  isProxyFetchError,
   getProxyInfo,
   isFetchAvailable,
   getFetchInfo,
@@ -52,6 +54,7 @@ export {
 // Export proxy utilities
 export {
   initializeProxy,
+  refreshProxy,
   isProxyConfigured,
   getProxyType,
   getAgentForUrl,
@@ -60,3 +63,7 @@ export {
 // Export tool-call hooks (embedding packages can piggyback on the live session)
 export { registerToolCallHook } from './lib/tool-call-hooks.js';
 export type { ToolCallHook, ToolCallContext } from './lib/tool-call-hooks.js';
+
+// Export opt-in request recovery hooks for embedding packages.
+export { registerRequestRecoveryHook } from './lib/request-recovery-hooks.js';
+export type { RequestRecoveryHook, RequestRecoveryContext } from './lib/request-recovery-hooks.js';

--- a/src/lib/fetch-utils.ts
+++ b/src/lib/fetch-utils.ts
@@ -7,6 +7,7 @@
 
 import type { RequestInit as NodeFetchRequestInit } from 'node-fetch';
 import type { Agent } from 'http';
+import { SocksProxyAgent } from 'socks-proxy-agent';
 import { logger } from './utils.js';
 import { getConfig } from './config.js';
 import { initializeProxy, getAgentForUrl, isProxyConfigured, getProxyType } from './proxy-utils.js';
@@ -14,8 +15,65 @@ import { initializeProxy, getAgentForUrl, isProxyConfigured, getProxyType } from
 /**
  * Extended RequestInit that includes the agent property for proxy support
  */
-interface ProxyRequestInit extends NodeFetchRequestInit {
-  agent?: Agent;
+type ProxyRequestInit = NodeFetchRequestInit;
+
+/** A network failure from a fetch that actually selected a proxy agent. */
+export class ProxyFetchError extends Error {
+  public readonly cause: unknown;
+  public readonly code?: string;
+  public readonly redirected: boolean;
+
+  constructor(cause: unknown, code?: string, redirected: boolean = false) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = 'ProxyFetchError';
+    this.cause = cause;
+    this.code = code;
+    this.redirected = redirected;
+    Object.setPrototypeOf(this, ProxyFetchError.prototype);
+  }
+}
+
+export function isProxyFetchError(error: unknown): error is ProxyFetchError {
+  return error instanceof ProxyFetchError;
+}
+
+type NodeFetchImplementation = (url: string, init: ProxyRequestInit) => Promise<unknown>;
+
+/**
+ * Execute a request after a proxy agent has been selected, preserving that
+ * attribution if the network attempt fails.
+ *
+ * @internal Exported for focused unit coverage; not part of the package barrel.
+ */
+export async function fetchWithProxyAgent(
+  nodeFetch: NodeFetchImplementation,
+  url: string,
+  init: RequestInit | undefined,
+  agent: Agent
+): Promise<Response> {
+  // node-fetch invokes the agent selector for each hop, including redirects
+  // back to the same URL. A later refusal cannot prove the first hop was safe.
+  let hops = 0;
+  const selectAgent = () => {
+    hops++;
+    return agent;
+  };
+  try {
+    return (await nodeFetch(url, { ...init, agent: selectAgent } as ProxyRequestInit)) as Response;
+  } catch (error) {
+    // socks converts socket errors to message-only SocksClientErrors, so
+    // node-fetch cannot retain their code.
+    const failure = error as { type?: string; code?: string; message?: string };
+    const proxyHost = agent instanceof SocksProxyAgent ? agent.proxy.host : undefined;
+    const refused =
+      agent instanceof SocksProxyAgent &&
+      proxyHost !== undefined &&
+      failure?.type === 'system' &&
+      failure.code === undefined &&
+      failure.message ===
+        `request to ${new URL(url).href} failed, reason: connect ECONNREFUSED ${proxyHost}:${agent.proxy.port}`;
+    throw new ProxyFetchError(error, refused ? 'ECONNREFUSED' : undefined, hops > 1);
+  }
 }
 
 /**
@@ -74,7 +132,7 @@ export async function proxyFetch(url: string, init?: RequestInit): Promise<Respo
   if (agent) {
     // Use node-fetch with agent for SOCKS/HTTP proxy support
     const nodeFetch = (await import('node-fetch')).default;
-    return nodeFetch(url, { ...init, agent } as ProxyRequestInit) as unknown as Response;
+    return fetchWithProxyAgent(nodeFetch, url, init, agent);
   }
 
   // Direct connection (no proxy configured or PAC returned DIRECT)

--- a/src/lib/oauth-types.ts
+++ b/src/lib/oauth-types.ts
@@ -136,13 +136,19 @@ export class APIError extends Error {
   public readonly response?: any;
   /** Underlying network/TLS error code (e.g. "UNABLE_TO_VERIFY_LEAF_SIGNATURE"), when the failure was below the HTTP layer. */
   public readonly code?: string;
+  /** Whether the failed network attempt selected a proxy agent. */
+  public readonly viaProxy: boolean;
+  /** A prior redirect hop may already have executed the original operation. */
+  public readonly redirected: boolean;
 
   constructor(
     message: string,
     statusCode: number,
     endpoint: string,
     response?: any,
-    code?: string
+    code?: string,
+    viaProxy: boolean = false,
+    redirected: boolean = false
   ) {
     super(message);
     this.name = 'APIError';
@@ -150,6 +156,8 @@ export class APIError extends Error {
     this.endpoint = endpoint;
     this.response = response;
     this.code = code;
+    this.viaProxy = viaProxy;
+    this.redirected = redirected;
 
     // Ensure proper prototype chain
     Object.setPrototypeOf(this, APIError.prototype);

--- a/src/lib/proxy-utils.ts
+++ b/src/lib/proxy-utils.ts
@@ -15,6 +15,8 @@ import { logger } from './utils.js';
 // Dynamic imports for PAC resolver (has WASM dependencies)
 type PacResolverFn = (url: string) => Promise<string>;
 
+const DEFAULT_PAC_LOAD_TIMEOUT_MS = 5000;
+
 type ProxyAgent = SocksProxyAgent | HttpsProxyAgent<string>;
 
 interface ProxyConfig {
@@ -25,6 +27,7 @@ interface ProxyConfig {
 
 let proxyConfig: ProxyConfig = { type: 'none' };
 let initializationPromise: Promise<void> | null = null;
+let refreshPromise: Promise<void> | null = null;
 
 interface MacOsProxyInfo {
   pacUrl: string | null;
@@ -75,6 +78,45 @@ function sanitizeProxyUrl(url: string): string {
     return parsed.toString();
   } catch {
     return url.replace(/\/\/[^:]+:[^@]+@/, '//***:***@');
+  }
+}
+
+function getPacLoadTimeoutMs(): number {
+  const configured = parseInt(process.env.PROXY_PAC_TIMEOUT_MS || '', 10);
+  return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_PAC_LOAD_TIMEOUT_MS;
+}
+
+async function loadPacResolver(pacUrl: string, signal: AbortSignal): Promise<PacResolverFn> {
+  const response = await fetch(pacUrl, { signal });
+  if (!response.ok) {
+    throw new Error(`PAC request failed with HTTP ${response.status}`);
+  }
+  const pacScript = await response.text();
+
+  const { getQuickJS } = await import('@tootallnate/quickjs-emscripten');
+  const { createPacResolver } = await import('pac-resolver');
+  const qjs = await getQuickJS();
+  return createPacResolver(qjs, pacScript);
+}
+
+async function loadPacResolverWithTimeout(pacUrl: string): Promise<PacResolverFn> {
+  const timeoutMs = getPacLoadTimeoutMs();
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`PAC initialization timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([loadPacResolver(pacUrl, controller.signal), timeoutPromise]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
   }
 }
 
@@ -164,17 +206,58 @@ export async function initializeProxy(
     return initializationPromise;
   }
 
-  initializationPromise = doInitializeProxy(detectMacOs).catch(error => {
-    initializationPromise = null;
-    throw error;
-  });
+  initializationPromise = resolveProxyConfig(detectMacOs)
+    .then(config => {
+      proxyConfig = config;
+    })
+    .catch(error => {
+      initializationPromise = null;
+      throw error;
+    });
   return initializationPromise;
 }
 
 /**
- * Internal initialization logic
+ * Refresh proxy configuration from the current environment and operating-system
+ * settings. Concurrent refreshes share the same work, while later refreshes can
+ * run again after the system proxy changes.
+ *
+ * The active configuration is replaced only after detection completes so
+ * in-flight requests never observe a partially initialized PAC resolver.
+ *
+ * @param detectMacOs - Optional override for macOS proxy detection (testing seam)
  */
-async function doInitializeProxy(detectMacOs: MacOsProxyDetector): Promise<void> {
+export async function refreshProxy(
+  detectMacOs: MacOsProxyDetector = detectMacOsProxy
+): Promise<void> {
+  if (refreshPromise) {
+    return refreshPromise;
+  }
+
+  const currentRefresh = (async () => {
+    if (initializationPromise) {
+      await initializationPromise;
+    }
+
+    const config = await resolveProxyConfig(detectMacOs);
+    proxyConfig = config;
+  })();
+
+  refreshPromise = currentRefresh;
+
+  try {
+    await currentRefresh;
+  } finally {
+    if (refreshPromise === currentRefresh) {
+      refreshPromise = null;
+    }
+  }
+}
+
+/**
+ * Resolve a complete proxy configuration without changing the active one.
+ */
+async function resolveProxyConfig(detectMacOs: MacOsProxyDetector): Promise<ProxyConfig> {
   // 1. Explicit environment proxy takes precedence over auto-detected system
   //    proxies. Setting SOCKS_PROXY/HTTPS_PROXY/ALL_PROXY/HTTP_PROXY is a
   //    deliberate operator choice — including the URL scheme. The scheme
@@ -187,9 +270,8 @@ async function doInitializeProxy(detectMacOs: MacOsProxyDetector): Promise<void>
   //    most HTTP clients.
   const envProxy = detectEnvProxy();
   if (envProxy) {
-    proxyConfig = { type: 'env', envProxy };
     logger.info(`Proxy configured from environment: ${sanitizeProxyUrl(envProxy.url)}`, 'PROXY');
-    return;
+    return { type: 'env', envProxy };
   }
 
   // 2. Try macOS system proxy (single scutil call for both PAC and SOCKS)
@@ -198,24 +280,17 @@ async function doInitializeProxy(detectMacOs: MacOsProxyDetector): Promise<void>
   // 2a. PAC file
   if (macProxy?.pacUrl) {
     try {
-      // Fetch PAC file directly (not through proxy)
-      const response = await fetch(macProxy.pacUrl);
-      const pacScript = await response.text();
+      // Fetch and compile the PAC directly, within a bounded startup window.
+      // The returned resolver is still local here, so timeout or late
+      // completion cannot partially update the active proxy configuration.
+      const resolver = await loadPacResolverWithTimeout(macProxy.pacUrl);
 
-      // Dynamic import for PAC resolver (has WASM dependencies)
-      const { getQuickJS } = await import('@tootallnate/quickjs-emscripten');
-      const { createPacResolver } = await import('pac-resolver');
-
-      // Initialize QuickJS for PAC evaluation
-      const qjs = await getQuickJS();
-      const resolver = createPacResolver(qjs, pacScript);
-
-      proxyConfig = {
+      const config: ProxyConfig = {
         type: 'pac',
         pacResolver: resolver,
       };
       logger.info(`PAC proxy initialized from ${sanitizeProxyUrl(macProxy.pacUrl)}`, 'PROXY');
-      return;
+      return config;
     } catch (error) {
       logger.error(`Failed to initialize PAC proxy: ${error}`, 'PROXY');
     }
@@ -226,14 +301,13 @@ async function doInitializeProxy(detectMacOs: MacOsProxyDetector): Promise<void>
     const { host, port } = macProxy.socks;
     const bracketedHost = host.includes(':') ? `[${host}]` : host;
     const socksUrl = `socks5h://${bracketedHost}:${port}`;
-    proxyConfig = { type: 'env', envProxy: { url: socksUrl, type: 'socks' } };
     logger.info(`System SOCKS proxy configured: ${sanitizeProxyUrl(socksUrl)}`, 'PROXY');
-    return;
+    return { type: 'env', envProxy: { url: socksUrl, type: 'socks' } };
   }
 
   // 3. No proxy configured
   logger.debug('No proxy configured', 'PROXY');
-  proxyConfig = { type: 'none' };
+  return { type: 'none' };
 }
 
 /**

--- a/src/lib/request-recovery-hooks.ts
+++ b/src/lib/request-recovery-hooks.ts
@@ -1,0 +1,73 @@
+/**
+ * Opt-in request recovery hooks for embedding packages.
+ *
+ * The base proxy does not decide which application responses are safe to
+ * retry. An embedding package can inspect the first outcome, perform its own
+ * recovery action, and return true to request one retry.
+ *
+ * The registry uses a global symbol so registrations made through the `/lib`
+ * bundle are visible to the separately bundled proxy entry point.
+ */
+
+import { logger } from './utils.js';
+import type { APIError } from './oauth-types.js';
+import type { WordPressResponse } from './types.js';
+
+export interface RequestRecoveryContext {
+  /** WordPress/MCP method from the original request. */
+  method: string;
+  /** Refresh the proxy state used by the request path invoking this hook. */
+  refreshProxy: () => Promise<void>;
+  /** First successful transport response, when the request did not throw. */
+  response?: WordPressResponse;
+  /** First API failure, when the request did throw. */
+  error?: APIError;
+}
+
+/**
+ * Return true after completing recovery to request one retry. Hook failures
+ * are isolated so an optional policy cannot replace the original outcome.
+ */
+export type RequestRecoveryHook = (context: RequestRecoveryContext) => boolean | Promise<boolean>;
+
+const REGISTRY_KEY = Symbol.for('@automattic/mcp-wordpress-remote:request-recovery-hooks');
+
+function getRegistry(): Set<RequestRecoveryHook> {
+  const globalObject = globalThis as Record<PropertyKey, unknown>;
+  let registry = globalObject[REGISTRY_KEY] as Set<RequestRecoveryHook> | undefined;
+  if (!registry) {
+    registry = new Set<RequestRecoveryHook>();
+    globalObject[REGISTRY_KEY] = registry;
+  }
+  return registry;
+}
+
+/** Register an opt-in recovery policy and return its unregister function. */
+export function registerRequestRecoveryHook(hook: RequestRecoveryHook): () => void {
+  const registry = getRegistry();
+  registry.add(hook);
+  return () => {
+    registry.delete(hook);
+  };
+}
+
+/**
+ * Ask registered policies whether the first request outcome should be retried.
+ * The caller owns the one-retry limit; this function only evaluates policies.
+ */
+export async function runRequestRecoveryHooks(context: RequestRecoveryContext): Promise<boolean> {
+  const hooks = [...getRegistry()];
+
+  for (const hook of hooks) {
+    try {
+      if (await hook(context)) {
+        return true;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Request-recovery hook failed: ${message}`, 'HOOKS');
+    }
+  }
+
+  return false;
+}

--- a/src/lib/wordpress-api.ts
+++ b/src/lib/wordpress-api.ts
@@ -7,7 +7,7 @@ import { createParser } from 'eventsource-parser';
 import { WordPressRequestParams, WordPressResponse } from './types.js';
 import { logger, LogLevel } from './utils.js';
 import { CONFIG, validateConfig, getDefaultOAuthScopes, getCustomHeaders } from './config.js';
-import { proxyFetch } from './fetch-utils.js';
+import { isProxyFetchError, proxyFetch } from './fetch-utils.js';
 import { WPTokens, AuthError, APIError } from './oauth-types.js';
 import {
   extractNetworkErrorCode,
@@ -22,6 +22,8 @@ import {
 import { PersistentWPOAuthClientProvider } from './persistent-oauth-client-provider.js';
 import { MCPOAuthProvider } from './mcp-oauth-provider.js';
 import { createLazyWPAuthCoordinator } from './coordination.js';
+import { runRequestRecoveryHooks } from './request-recovery-hooks.js';
+import { refreshProxy } from './proxy-utils.js';
 
 /**
  * WordPress API request function with OAuth, JWT, and Basic Auth support
@@ -43,6 +45,7 @@ let sessionRefreshPromise: Promise<void> | null = null;
 
 const WP_MCP_ENDPOINT = '/wp/v2/wpmcp';
 const INVALID_SESSION_ERROR_CODES = new Set([-32602, -32005]);
+const INTERNAL_ERROR_CODE = -32603;
 const INVALID_SESSION_ERROR_MESSAGE = 'Invalid or expired session';
 const SESSION_NOT_FOUND_ERROR_MESSAGE = 'Session not found';
 
@@ -262,13 +265,16 @@ function isInvalidSessionError(error: APIError): boolean {
       : errorResponse;
   const code = typeof jsonRpcError?.code === 'number' ? jsonRpcError.code : null;
   const message = typeof jsonRpcError?.message === 'string' ? jsonRpcError.message : '';
+  const explicitlyExpired = message.includes(INVALID_SESSION_ERROR_MESSAGE);
+
+  if (code === INTERNAL_ERROR_CODE) {
+    return explicitlyExpired;
+  }
 
   return (
     code !== null &&
     INVALID_SESSION_ERROR_CODES.has(code) &&
-    (message === INVALID_SESSION_ERROR_MESSAGE ||
-      message.includes(SESSION_NOT_FOUND_ERROR_MESSAGE) ||
-      message.includes(INVALID_SESSION_ERROR_MESSAGE))
+    (message.includes(SESSION_NOT_FOUND_ERROR_MESSAGE) || explicitlyExpired)
   );
 }
 
@@ -284,6 +290,7 @@ function updateSessionId(sessionId: string): void {
 interface RequestExecutionResult {
   responseData: WordPressResponse;
   sessionIdUsed: string | null;
+  redirected: boolean;
 }
 
 async function executeWordPressRequest(
@@ -434,11 +441,13 @@ async function executeWordPressRequest(
     signal: AbortSignal.timeout(timeoutMs),
   };
 
+  let redirected = false;
   try {
     logger.api('Sending request to WordPress API...');
     logger.debug(`Request URL: ${url}`, 'API');
     logger.debug(`Request method: ${method} (timeout ${timeoutMs}ms)`, 'API');
     const response = await proxyFetch(url, fetchOptions);
+    redirected = response.redirected;
     logger.debug(`Response status: ${response.status}`, 'API');
 
     const rawBody = await response.text();
@@ -450,7 +459,10 @@ async function executeWordPressRequest(
         `WordPress API error (${response.status}): ${rawBody}`,
         response.status,
         url,
-        rawBody
+        rawBody,
+        undefined,
+        false,
+        redirected
       );
     }
 
@@ -486,13 +498,17 @@ async function executeWordPressRequest(
             `WordPress JSON-RPC error: ${jsonrpcResponse.error.message}`,
             jsonrpcResponse.error.code || 500,
             url,
-            jsonrpcResponse.error
+            jsonrpcResponse.error,
+            undefined,
+            false,
+            redirected
           );
         } else if (jsonrpcResponse.result !== undefined) {
           // Extract result from JSON-RPC response
           return {
             responseData: jsonrpcResponse.result as WordPressResponse,
             sessionIdUsed,
+            redirected,
           };
         }
       }
@@ -502,6 +518,7 @@ async function executeWordPressRequest(
     return {
       responseData: responseData as WordPressResponse,
       sessionIdUsed,
+      redirected,
     };
   } catch (error) {
     if (error instanceof APIError) {
@@ -514,7 +531,9 @@ async function executeWordPressRequest(
     // (node-fetch uses "AbortError"). DOMException is not `instanceof Error` in
     // Node, so match on the name directly. Normalize to ETIMEDOUT so it carries
     // a meaningful code and hint.
-    const errorName = (error as { name?: unknown })?.name;
+    const viaProxy = isProxyFetchError(error);
+    const underlyingError = viaProxy ? error.cause : error;
+    const errorName = (underlyingError as { name?: unknown })?.name;
     const isTimeout = errorName === 'TimeoutError' || errorName === 'AbortError';
     const code = isTimeout ? 'ETIMEDOUT' : extractNetworkErrorCode(error);
     const hint = getConnectionErrorHint(code);
@@ -527,7 +546,15 @@ async function executeWordPressRequest(
     if (hint) {
       logger.error(hint, 'API');
     }
-    throw new APIError(errorMessage, 0, url, undefined, code);
+    throw new APIError(
+      errorMessage,
+      0,
+      url,
+      undefined,
+      code,
+      viaProxy,
+      redirected || (viaProxy && error.redirected)
+    );
   }
 }
 
@@ -595,13 +622,30 @@ export async function wpRequest(
   }
 
   const sessionIdUsed = globalSessionId;
+  let requestRecoveryAttempted = false;
 
   try {
     const result = await executeWordPressRequest(requestData, useJsonRpc, sessionIdUsed);
+
+    if (
+      !result.redirected &&
+      (await runRequestRecoveryHooks({
+        method: requestData?.method || 'unknown',
+        refreshProxy,
+        response: result.responseData,
+      }))
+    ) {
+      requestRecoveryAttempted = true;
+      const retriedResult = await executeWordPressRequest(requestData, useJsonRpc, globalSessionId);
+      return retriedResult.responseData;
+    }
+
     return result.responseData;
   } catch (error) {
     if (
+      !requestRecoveryAttempted &&
       error instanceof APIError &&
+      !error.redirected &&
       allowSessionRecovery &&
       !isInitializeRequest(requestData) &&
       isInvalidSessionError(error)
@@ -613,6 +657,20 @@ export async function wpRequest(
 
       await refreshSession(sessionIdUsed);
 
+      const retriedResult = await executeWordPressRequest(requestData, useJsonRpc, globalSessionId);
+      return retriedResult.responseData;
+    }
+
+    if (
+      !requestRecoveryAttempted &&
+      error instanceof APIError &&
+      !error.redirected &&
+      (await runRequestRecoveryHooks({
+        method: requestData?.method || 'unknown',
+        refreshProxy,
+        error,
+      }))
+    ) {
       const retriedResult = await executeWordPressRequest(requestData, useJsonRpc, globalSessionId);
       return retriedResult.responseData;
     }

--- a/tests/runtime/redirect-recovery.test.mjs
+++ b/tests/runtime/redirect-recovery.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import nock from 'nock';
+
+// Run after npm run build. Exercise the real bundled node-fetch redirect path.
+test('a proxy refusal after a redirect never replays the original write', async () => {
+  process.env.USE_SYSTEM_PROXY = 'true';
+  process.env.SOCKS_PROXY = 'socks5h://127.0.0.1:8080';
+  process.env.NO_PROXY = 'localhost';
+  process.env.WP_API_URL = 'https://redirect.example/mcp';
+  process.env.JWT_TOKEN = 'test-only';
+  process.env.OAUTH_ENABLED = 'false';
+  const { initializeProxy, wpRequest, registerRequestRecoveryHook } = await import(
+    '../../dist/lib.js'
+  );
+  await initializeProxy();
+  let hookCalls = 0;
+  let writes = 0;
+  nock.disableNetConnect();
+  const scope = nock('https://redirect.example')
+    .post('/mcp')
+    .reply(() => {
+      writes++;
+      return [303, '', { Location: '/result' }];
+    })
+    .get('/result')
+    .replyWithError(Object.assign(new Error('connection refused'), { code: 'ECONNREFUSED' }));
+  const unregister = registerRequestRecoveryHook(() => {
+    hookCalls++;
+    return true;
+  });
+  try {
+    await assert.rejects(wpRequest({ method: 'tools/call', params: { name: 'write' } }), error => {
+      assert.equal(error.code, 'ECONNREFUSED');
+      assert.equal(error.viaProxy, true);
+      assert.equal(error.redirected, true);
+      return true;
+    });
+    assert.equal(writes, 1);
+    assert.equal(hookCalls, 0);
+    assert.equal(scope.isDone(), true);
+  } finally {
+    unregister();
+    nock.cleanAll();
+    nock.enableNetConnect();
+  }
+});

--- a/tests/runtime/socks-refusal.test.mjs
+++ b/tests/runtime/socks-refusal.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:net';
+import { once } from 'node:events';
+import test from 'node:test';
+
+// Run after npm run build. Uses the real bundled node-fetch and SOCKS stack.
+test('closed SOCKS listener retains ECONNREFUSED through wpRequest', async () => {
+  const listener = createServer();
+  listener.listen(0, '127.0.0.1');
+  await once(listener, 'listening');
+  const port = listener.address().port;
+  await new Promise((resolve, reject) =>
+    listener.close(error => (error ? reject(error) : resolve()))
+  );
+
+  process.env.USE_SYSTEM_PROXY = 'true';
+  process.env.SOCKS_PROXY = `socks5h://127.0.0.1:${port}`;
+  process.env.NO_PROXY = 'localhost';
+  process.env.WP_API_URL = 'https://example.invalid/mcp';
+  process.env.JWT_TOKEN = 'test-only';
+  process.env.OAUTH_ENABLED = 'false';
+  const { initializeProxy, wpRequest, registerRequestRecoveryHook } = await import(
+    '../../dist/lib.js'
+  );
+  await initializeProxy();
+  let observed;
+  const unregister = registerRequestRecoveryHook(context => {
+    observed = context.error;
+    return false;
+  });
+  try {
+    await assert.rejects(wpRequest({ method: 'tools/list' }), error => {
+      assert.equal(error.code, 'ECONNREFUSED');
+      assert.equal(error.viaProxy, true);
+      assert.equal(error, observed);
+      return true;
+    });
+  } finally {
+    unregister();
+  }
+});

--- a/tests/unit/fetch-utils.test.ts
+++ b/tests/unit/fetch-utils.test.ts
@@ -1,0 +1,80 @@
+import { Agent } from 'node:http';
+import { SocksProxyAgent } from 'socks-proxy-agent';
+
+describe('proxy fetch attribution', () => {
+  let fetchWithProxyAgent: typeof import('../../src/lib/fetch-utils.js').fetchWithProxyAgent;
+  let isProxyFetchError: typeof import('../../src/lib/fetch-utils.js').isProxyFetchError;
+
+  beforeAll(async () => {
+    ({ fetchWithProxyAgent, isProxyFetchError } = await import('../../src/lib/fetch-utils.js'));
+  });
+
+  it('marks a network failure when a proxy agent was selected', async () => {
+    const cause = Object.assign(new Error('connection refused'), { code: 'ECONNREFUSED' });
+    const nodeFetch = () => Promise.reject(cause);
+    const error = await fetchWithProxyAgent(
+      nodeFetch,
+      'https://example.com',
+      undefined,
+      new Agent()
+    ).catch(value => value);
+
+    expect(isProxyFetchError(error)).toBe(true);
+    expect(error.cause).toBe(cause);
+  });
+
+  it('does not mark an ordinary network failure', () => {
+    const cause = Object.assign(new Error('connection refused'), { code: 'ECONNREFUSED' });
+
+    expect(isProxyFetchError(cause)).toBe(false);
+  });
+
+  it('marks a refusal after a redirect as potentially already executed', async () => {
+    const cause = Object.assign(new Error('connection refused'), { code: 'ECONNREFUSED' });
+    const agent = new Agent();
+    const nodeFetch = async (_url: string, init: any) => {
+      expect(init.agent(new URL('http://redirect.example/write'))).toBe(agent);
+      expect(init.agent(new URL('http://redirect.example/result'))).toBe(agent);
+      throw cause;
+    };
+    const error = await fetchWithProxyAgent(
+      nodeFetch,
+      'http://redirect.example/write',
+      { method: 'POST', body: 'payload' },
+      agent
+    ).catch(value => value);
+
+    expect(isProxyFetchError(error)).toBe(true);
+    expect(error.redirected).toBe(true);
+    expect(error.cause.code).toBe('ECONNREFUSED');
+  });
+
+  it.each([
+    ['connect ECONNREFUSED 127.0.0.1:8080', 'system', undefined, 'ECONNREFUSED'],
+    ['connect ECONNREFUSED 127.0.0.1:8081', 'system', undefined, undefined],
+    ['connect ETIMEDOUT 127.0.0.1:8080', 'system', undefined, undefined],
+    ['connect ECONNREFUSED 127.0.0.1:8080', 'aborted', undefined, undefined],
+    ['connect ECONNREFUSED 127.0.0.1:8080', 'system', 'ETIMEDOUT', undefined],
+    ['SOCKS handshake failed', 'system', undefined, undefined],
+  ])(
+    'normalizes only a matching SOCKS refusal (%s, %s, %s)',
+    async (reason, type, code, expected) => {
+      const cause = Object.assign(
+        new Error(`request to https://example.com/ failed, reason: ${reason}`),
+        {
+          name: 'FetchError2',
+          type,
+          code,
+        }
+      );
+      const error = await fetchWithProxyAgent(
+        () => Promise.reject(cause),
+        'https://example.com',
+        undefined,
+        new SocksProxyAgent('socks5h://127.0.0.1:8080')
+      ).catch(value => value);
+      expect(error.code).toBe(expected);
+      expect(error.cause).toBe(cause);
+    }
+  );
+});

--- a/tests/unit/proxy-init.test.ts
+++ b/tests/unit/proxy-init.test.ts
@@ -72,4 +72,91 @@ describe('doInitializeProxy precedence', () => {
     expect(detectMacOs).toHaveBeenCalledTimes(1);
     expect(proxy.getProxyType()).toBe('none');
   });
+
+  it('refreshes proxy configuration after system settings change', async () => {
+    restoreEnv = mockEnv(NO_PROXY_ENV);
+
+    const proxy = await import('../../src/lib/proxy-utils.js');
+    await proxy.initializeProxy(() => ({ pacUrl: null, socks: null }));
+
+    expect(proxy.getProxyType()).toBe('none');
+
+    await proxy.refreshProxy(() => ({
+      pacUrl: null,
+      socks: { host: '127.0.0.1', port: '8080' },
+    }));
+
+    expect(proxy.getProxyType()).toBe('env');
+    const agent = await proxy.getAgentForUrl('https://example.com');
+    expect(agent?.constructor.name).toBe('SocksProxyAgent');
+  });
+
+  it('coalesces concurrent refreshes', async () => {
+    restoreEnv = mockEnv(NO_PROXY_ENV);
+
+    const proxy = await import('../../src/lib/proxy-utils.js');
+    await proxy.initializeProxy(() => ({ pacUrl: null, socks: null }));
+
+    const detectMacOs = jest.fn<() => MacOsProxyInfo | null>(() => ({
+      pacUrl: null,
+      socks: { host: '127.0.0.1', port: '8080' },
+    }));
+
+    await Promise.all([proxy.refreshProxy(detectMacOs), proxy.refreshProxy(detectMacOs)]);
+
+    expect(detectMacOs).toHaveBeenCalledTimes(1);
+    expect(proxy.getProxyType()).toBe('env');
+  });
+
+  it('allows later refreshes after another system proxy change', async () => {
+    restoreEnv = mockEnv(NO_PROXY_ENV);
+
+    const proxy = await import('../../src/lib/proxy-utils.js');
+    await proxy.initializeProxy(() => ({ pacUrl: null, socks: null }));
+
+    const detectMacOs = jest
+      .fn<() => MacOsProxyInfo | null>()
+      .mockReturnValueOnce({
+        pacUrl: null,
+        socks: { host: '127.0.0.1', port: '8080' },
+      })
+      .mockReturnValueOnce({ pacUrl: null, socks: null });
+
+    await proxy.refreshProxy(detectMacOs);
+    expect(proxy.getProxyType()).toBe('env');
+
+    await proxy.refreshProxy(detectMacOs);
+    expect(proxy.getProxyType()).toBe('none');
+    expect(detectMacOs).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds PAC initialization and swaps configuration only after it settles', async () => {
+    restoreEnv = mockEnv({ ...NO_PROXY_ENV, PROXY_PAC_TIMEOUT_MS: '20' });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = jest.fn(() => new Promise<Response>(() => {})) as typeof fetch;
+
+    try {
+      const proxy = await import('../../src/lib/proxy-utils.js');
+      await proxy.initializeProxy(() => ({
+        pacUrl: null,
+        socks: { host: '127.0.0.1', port: '8080' },
+      }));
+
+      const refresh = proxy.refreshProxy(() => ({
+        pacUrl: 'https://pac.example.com/proxy.pac',
+        socks: null,
+      }));
+
+      // Refresh waits for a complete replacement; the working configuration
+      // remains available while PAC loading is still pending.
+      expect(proxy.getProxyType()).toBe('env');
+
+      await refresh;
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      expect(proxy.getProxyType()).toBe('none');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/tests/unit/wordpress-api.test.ts
+++ b/tests/unit/wordpress-api.test.ts
@@ -449,7 +449,10 @@ describe('WordPress API Module', () => {
         ).rejects.toThrow('No "message" event');
       });
 
-      it('should refresh the session once and retry the original request', async () => {
+      it.each([
+        ['invalid-params response', -32602],
+        ['internal-error wrapper', -32603],
+      ])('should refresh the session once for an expired-session %s', async (_label, errorCode) => {
         restoreEnv = mockEnv({
           WP_API_URL: 'https://my-wp-site.com',
           JWT_TOKEN: 'test-token',
@@ -505,7 +508,7 @@ describe('WordPress API Module', () => {
         nock('https://my-wp-site.com')
           .post(WP_MCP_ENDPOINT, toolRequest)
           .matchHeader('mcp-session-id', 'session-1')
-          .reply(200, createJsonRpcError(2, -32602, 'Invalid or expired session'));
+          .reply(200, createJsonRpcError(2, errorCode, 'Invalid or expired session'));
 
         nock('https://my-wp-site.com')
           .post(WP_MCP_ENDPOINT, toolRequest)
@@ -731,6 +734,189 @@ describe('WordPress API Module', () => {
         );
       });
 
+      it('allows an opt-in hook to recover a response and retry it once', async () => {
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://my-wp-site.com',
+          JWT_TOKEN: 'test-token',
+        });
+
+        const request = { jsonrpc: '2.0', id: 1, method: 'tools/call', params: {} };
+        const recoverableResponse = { isError: true, content: [{ type: 'text', text: 'retry' }] };
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, request)
+          .reply(200, createJsonRpcResult(1, recoverableResponse))
+          .post(WP_MCP_ENDPOINT, request)
+          .reply(200, createJsonRpcResult(1, { content: [] }));
+
+        const { registerRequestRecoveryHook } = await import(
+          '../../src/lib/request-recovery-hooks.js'
+        );
+        const hook = jest.fn(async ({ response, refreshProxy }: any) => {
+          expect(typeof refreshProxy).toBe('function');
+          return response?.isError === true;
+        });
+        const unregister = registerRequestRecoveryHook(hook);
+
+        try {
+          const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+          await expect(wpRequest(request, true)).resolves.toEqual({ content: [] });
+          expect(hook).toHaveBeenCalledTimes(1);
+          expect(nock.isDone()).toBe(true);
+        } finally {
+          unregister();
+        }
+      });
+
+      it('allows an opt-in hook to recover an APIError and retry it once', async () => {
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://my-wp-site.com',
+          JWT_TOKEN: 'test-token',
+        });
+
+        const request = { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} };
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, request)
+          .reply(503, 'temporarily unavailable')
+          .post(WP_MCP_ENDPOINT, request)
+          .reply(200, createJsonRpcResult(1, { tools: [] }));
+
+        const { registerRequestRecoveryHook } = await import(
+          '../../src/lib/request-recovery-hooks.js'
+        );
+        const hook = jest.fn(async ({ error, refreshProxy }: any) => {
+          expect(typeof refreshProxy).toBe('function');
+          return error?.statusCode === 503;
+        });
+        const unregister = registerRequestRecoveryHook(hook);
+
+        try {
+          const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+          await expect(wpRequest(request, true)).resolves.toEqual({ tools: [] });
+          expect(hook).toHaveBeenCalledTimes(1);
+          expect(nock.isDone()).toBe(true);
+        } finally {
+          unregister();
+        }
+      });
+
+      it('does not run recovery hooks again for the retry outcome', async () => {
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://my-wp-site.com',
+          JWT_TOKEN: 'test-token',
+        });
+
+        const request = { jsonrpc: '2.0', id: 1, method: 'tools/call', params: {} };
+        const recoverableResponse = { isError: true, content: [{ type: 'text', text: 'retry' }] };
+
+        nock('https://my-wp-site.com')
+          .post(WP_MCP_ENDPOINT, request)
+          .twice()
+          .reply(200, createJsonRpcResult(1, recoverableResponse));
+
+        const { registerRequestRecoveryHook } = await import(
+          '../../src/lib/request-recovery-hooks.js'
+        );
+        const hook = jest.fn(async () => true);
+        const unregister = registerRequestRecoveryHook(hook);
+
+        try {
+          const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+          await expect(wpRequest(request, true)).resolves.toEqual(recoverableResponse);
+          expect(hook).toHaveBeenCalledTimes(1);
+          expect(nock.isDone()).toBe(true);
+        } finally {
+          unregister();
+        }
+      });
+
+      it.each(['response', 'APIError'])(
+        'surfaces a thrown retry failure after recovering a %s without another recovery',
+        async firstOutcome => {
+          restoreEnv = mockEnv({
+            WP_API_URL: 'https://my-wp-site.com',
+            JWT_TOKEN: 'test-token',
+          });
+
+          const request = { jsonrpc: '2.0', id: 1, method: 'tools/call', params: {} };
+          const recoverableResponse = { isError: true, content: [{ type: 'text', text: 'retry' }] };
+          let requestCount = 0;
+          nock('https://my-wp-site.com')
+            .persist()
+            .post(WP_MCP_ENDPOINT, request)
+            .reply(() => {
+              requestCount++;
+              if (requestCount === 1 && firstOutcome === 'response') {
+                return [200, createJsonRpcResult(1, recoverableResponse)];
+              }
+              return [503, `failure on attempt ${requestCount}`];
+            });
+
+          const { registerRequestRecoveryHook } = await import(
+            '../../src/lib/request-recovery-hooks.js'
+          );
+          // Generic embedding policy: both outcomes would qualify if called again.
+          const hook = jest.fn(async () => true);
+          const unregister = registerRequestRecoveryHook(hook);
+
+          try {
+            const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+            await expect(wpRequest(request, true)).rejects.toMatchObject({
+              statusCode: 503,
+              message: expect.stringContaining('failure on attempt 2'),
+            });
+            expect(requestCount).toBe(2);
+            expect(hook).toHaveBeenCalledTimes(1);
+          } finally {
+            unregister();
+          }
+        }
+      );
+
+      it.each(['response', 'session error'])('does not recover a redirected %s', async outcome => {
+        restoreEnv = mockEnv({
+          WP_API_URL: 'https://my-wp-site.com',
+          JWT_TOKEN: 'test-token',
+          USE_SYSTEM_PROXY: 'false',
+        });
+        const request = { jsonrpc: '2.0', id: 1, method: 'tools/call', params: {} };
+        const denied = { isError: true, content: [{ type: 'text', text: 'retry' }] };
+        const response = new Response(
+          JSON.stringify(
+            outcome === 'response'
+              ? createJsonRpcResult(1, denied)
+              : createJsonRpcError(1, -32603, 'Invalid or expired session')
+          )
+        );
+        Object.defineProperty(response, 'redirected', { value: true });
+        const originalFetch = globalThis.fetch;
+        const fetchMock = jest.fn(async () => response);
+        globalThis.fetch = fetchMock as typeof fetch;
+        const { registerRequestRecoveryHook } = await import(
+          '../../src/lib/request-recovery-hooks.js'
+        );
+        const hook = jest.fn(async () => true);
+        const unregister = registerRequestRecoveryHook(hook);
+        try {
+          const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+          const result = wpRequest(request, true);
+          if (outcome === 'response') {
+            await expect(result).resolves.toEqual(denied);
+          } else {
+            await expect(result).rejects.toMatchObject({
+              redirected: true,
+              statusCode: -32603,
+            });
+          }
+          expect(hook).not.toHaveBeenCalled();
+          expect(fetchMock).toHaveBeenCalledTimes(1);
+        } finally {
+          unregister();
+          globalThis.fetch = originalFetch;
+        }
+      });
+
       it('should time out a slow request and report ETIMEDOUT', async () => {
         // Regression for issue #61: an unbounded fetch let a stalled upstream
         // hang the initialize handshake for ~60s. The request must now abort.
@@ -775,53 +961,60 @@ describe('WordPress API Module', () => {
         await expect(wpRequest({ method: 'initialize' })).rejects.toThrow();
       });
 
-      it('should not refresh the session for unrelated invalid-params errors', async () => {
-        restoreEnv = mockEnv({
-          WP_API_URL: 'https://my-wp-site.com',
-          JWT_TOKEN: 'test-token',
-        });
-
-        const initializeRequest = {
-          jsonrpc: '2.0',
-          id: 1,
-          method: 'initialize',
-          params: {
-            clientInfo: {
-              name: 'test-client',
-              version: '1.0.0',
-            },
-            _proxy_request_id: 1,
-          },
-        };
-        const toolRequest = {
-          jsonrpc: '2.0',
-          id: 2,
-          method: 'tools/list',
-          params: {
-            cursor: 'bad-cursor',
-          },
-        };
-
-        nock('https://my-wp-site.com')
-          .post(WP_MCP_ENDPOINT, initializeRequest)
-          .reply(200, createJsonRpcResult(1, { protocolVersion: '2025-06-18' }), {
-            'Mcp-Session-Id': 'session-1',
+      it.each([
+        ['invalid-params', -32602, 'Cursor is invalid'],
+        ['internal', -32603, 'Internal server error'],
+        ['internal session-not-found', -32603, 'Session not found'],
+      ])(
+        'should not refresh the session for an unrelated %s error',
+        async (_label, code, message) => {
+          restoreEnv = mockEnv({
+            WP_API_URL: 'https://my-wp-site.com',
+            JWT_TOKEN: 'test-token',
           });
 
-        nock('https://my-wp-site.com')
-          .post(WP_MCP_ENDPOINT, toolRequest)
-          .matchHeader('mcp-session-id', 'session-1')
-          .reply(200, createJsonRpcError(2, -32602, 'Cursor is invalid'));
+          const initializeRequest = {
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+              clientInfo: {
+                name: 'test-client',
+                version: '1.0.0',
+              },
+              _proxy_request_id: 1,
+            },
+          };
+          const toolRequest = {
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'tools/list',
+            params: {
+              cursor: 'bad-cursor',
+            },
+          };
 
-        const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+          nock('https://my-wp-site.com')
+            .post(WP_MCP_ENDPOINT, initializeRequest)
+            .reply(200, createJsonRpcResult(1, { protocolVersion: '2025-06-18' }), {
+              'Mcp-Session-Id': 'session-1',
+            });
 
-        await wpRequest(initializeRequest, true);
-        await expect(wpRequest(toolRequest, true)).rejects.toThrow(
-          'WordPress JSON-RPC error: Cursor is invalid'
-        );
+          nock('https://my-wp-site.com')
+            .post(WP_MCP_ENDPOINT, toolRequest)
+            .matchHeader('mcp-session-id', 'session-1')
+            .reply(200, createJsonRpcError(2, code, message));
 
-        expect(nock.isDone()).toBe(true);
-      });
+          const { wpRequest } = await import('../../src/lib/wordpress-api.js');
+
+          await wpRequest(initializeRequest, true);
+          await expect(wpRequest(toolRequest, true)).rejects.toThrow(
+            `WordPress JSON-RPC error: ${message}`
+          );
+
+          expect(nock.isDone()).toBe(true);
+        }
+      );
 
       it('should not retry initialize requests when initialize itself returns an invalid session error', async () => {
         restoreEnv = mockEnv({


### PR DESCRIPTION
## Summary

Improve client recovery from expired MCP sessions and changes to system proxy configuration.

- Recognize `-32603` errors containing `Invalid or expired session`.
- Add an opt-in recovery hook for embedding applications, limited to one retry.
- Refresh proxy configuration atomically and coalesce concurrent refreshes.
- Bound PAC download and resolver setup with `PROXY_PAC_TIMEOUT_MS`.
- Preserve proxy attribution and normalize message-only SOCKS connection refusals.
- Prevent recovery after redirects, where an earlier request may already have executed.

The base client does not interpret application-specific authorization failures. Embedding applications decide which failures permit proxy recovery.

## Testing

- Format and TypeScript checks passed.
- All 248 unit and integration tests passed.
- Runtime regressions verified initial SOCKS connection-refusal attribution and protection against replay after a redirect.